### PR TITLE
Suggest copywriting changes

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -33,7 +33,7 @@ member!**
 
 Expect BBQs (weather permitting), free breakfasts, board games nights, 
 Industry Panels and Info Sessions, volunteer opportunities within the Computer Science department, 
-the highly-anticipated Career Fair, and social events such as our year-end boat cruise!
+the highly-anticipated Career Fair, and social events such as our year-end gala!
 
 We also distribute all kinds of free stuff. Snag cool retractable CSSS pens and
 blue whiteboard markers, deck out your laptop with our signature CSSS and Cube 

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -29,35 +29,33 @@ serve all Computer Science students.
 **You don't have to! As long as you're a Computer Science student, you're a
 member!**
 
-### What we can do for you
+### What can we do for you?
 
-Expect BBQs (weather permitting), free breakfast, board games nights, the Career
-Fair, Industry Panels and Info Sessions, volunteer opportunities within the
-Computer Science Department, organizing the highly anticipated Career Fair, and
-holding social events such as licensed parties and the year-end boat cruise!
+Expect BBQs (weather permitting), free breakfasts, board games nights, 
+Industry Panels and Info Sessions, volunteer opportunities within the Computer Science department, 
+the highly-anticipated Career Fair, and social events such as our year-end boat cruise!
 
-We also distribute various free stuff, including annual dayplanners with monthly
-view, events/volunteer opportunities available through CSSS and the CS
-Department, a central map of UBC at the back; glossy CSSS pins; and lanyards,
-which are a beautiful blue colour and have a lobster clip attached at the end.
+We also distribute all kinds of free stuff. Snag cool retractable CSSS pens and
+blue whiteboard markers, deck out your laptop with our signature CSSS and Cube 
+vinyl stickers, pause your reading with a CSSS bookmark, or just come listen
+to the complimentary sage advice being dispensed in our clubroom.
 
-So come by and socialize with your CS peers: hang out, eat and be merry! We will
-organize many events just for CS students. We can also help you connect with the
-CS Department: we can't stress how important it is to dip your feet into
-volunteer opportunities within the CS department. You will really find a home in
-CS by helping out within the department. Increase your connections by networking
-with industry members at the career fair. Of course, we also have cheap food
-([Food Price List](/cube/menu)). Forget those greedy vending machines. We're not
+So come by and socialize with your CS peers; hang out, eat and be merry! We
+organize tons of events just for CS students. We can also help you dial into
+the rest of UBC CS. Find a home in the department by getting involved 
+with various volunteer opportunities. Increase your connections by networking
+with industry members at the career fair. And of course, we also stock cheap food
+([Food Price List](/cube/menu)). Forget those greedy vending machines — we're not
 pirates.
 
 ### Where is the CSSS lounge?
 
-You can find us in [ICICS 021](/cube/location/), which is just down the stairs from the front door
-of ICICS/CS, right, and at the end of the hallway by the undergraduate labs.
+You can find us in [ICICS 021](/cube/location/). Head just down the stairs from the front door
+of ICICS/CS, turn right, and we'll be at the end of the hallway, beside the undergraduate labs.
 
 ### How do I find out about CSSS events?
 
-We'll be posting our events here on our website (which also has an
+We'll be publishing our events here on our website (which also has an
 [RSS feed](/index.xml)), [Tweeting them](https://twitter.com/ubccsss), posting
 them on our [Facebook page](https://www.facebook.com/ubccsss/), and sending them
 to our [announcements mailing list](/contact/email-newsletter/).
@@ -69,12 +67,11 @@ We're always looking for volunteers to help with our events. Please see our
 
 ### How can I be involved in the running of CSSS?
 
-Just ask! We're always happy to have more volunteers, so if you're interested,
-take a look through the positions listed below. Our organization has a
+Just ask! We're always happy to bring more people on board. Our organization has a
 three-layer reporting structure: the president, the other core executives, and
-the committees. The core executives are elected each spring, while the committee
+the committees. The president and core executives are elected each spring, while committee
 members are appointed throughout the year. If you see a position that interests
-you, or just want to be involved as a volunteer, send us an e-mail to us at
+you, or just want to get involved, shoot us an e-mail at
 `csss [at] ubccsss [dot] org`.
 
 ### Our Mission Statement and Constitution
@@ -89,5 +86,5 @@ holding social events.
 For more information about the running of the club, please read our
 [constitution](/about/constitution).
 
-Thanks all! If you have any questions/concerns, please e-mail us at
+Thanks everyone! If you have any questions/concerns, please e-mail us at
 `csss [at] ubccsss [dot] org`!


### PR DESCRIPTION
Improve awkward flow, grammatical issues, paragraph development, coherence, verb strength, accuracy of information. Remove dangling modifiers and redundant ideas, as well as semicolon abuse and other punctuation mishaps. Smooth tone and add small rhetorical flair. 

Assumed we cannot modify mission statement.

Reviewer: @ubccsss/vp-communications

Thanks!
