### PR TITLE
Fix mobile nav not opening

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -42,3 +42,9 @@ a {
   max-height: 20em;
   overflow-x: hidden;
 }
+
+@media all and (max-width:768px) {
+  .blog-header .navbar, .navbar-brand {
+    transform: none;
+  }
+}


### PR DESCRIPTION
This PR fixes #78, in which we noticed that the top navbar was still slanted on mobile, as well as not opening on mobile.

The cause of this issue was the collapse plugin, which used different attributes on Bootstrap 5.0 compared to the version the theme was currently built against. This PR replaces the `data-toggle` / `data-target` with their Bootstrap 5.0 versions.

This PR also un-slants the top navbar on mobile. Keeping it slanted would have also slanted the text in the navbar pulldown. As well, the top slant wasn't significant enough on mobile, and might have seemed like a weird bug, so the page now has the navbar fully horizontal on mobile and slanted on desktop.