### PR TITLE
Update copyright to include 2021

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ permalinks:
 
 paginate: 5
 
-copyright: © 2019-2020
+copyright: © 2019-2021
 
 params:
   github:


### PR DESCRIPTION
This PR updates the copyright year range as per #72.