### PR TITLE
Add filtering for tutoring page

### DIFF
--- a/data/tutor.yaml
+++ b/data/tutor.yaml
@@ -15,12 +15,12 @@
 
 - name: Emily Gubski
   lastmod: 2021-11-21
-  courses: CPSC 103
+  courses: ["CPSC103"]
   email: emily.gubski@ubc.ca
 
 - name: Kamsi Oramasionwu 
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 210
+  courses: ["CPSC110", "CPSC210"]
   email: kamsi.oramasionwu@gmail.com
   rates: $25-30/hr
   availability: Tuesdays - 11-12 PST, Thursdays - 1-2 PST
@@ -29,27 +29,27 @@
 
 - name: XinRan Zhang
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 121, CPSC 210, CPSC 310, CPSC 312
+  courses: ["CPSC110", "CPSC121", "CPSC210", "CPSC310", "CPSC312"]
   email: xinran@zhangxinran.net
   availability: Weekend and some weekday, flexible
   rates: $30/hr
 
 - name: Rahim Mammadli
   lastmod: 2021-11-21
-  courses: CPSC 221, CPSC 320, CPSC 322
+  courses: ["CPSC221", "CPSC320", "CPSC322"]
   email: rehijm@mail.ru
   rates: $20/hr
 
 - name: Leo Sporn
   lastmod: 2021-11-21
-  courses: CPSC 121, CPSC 221, CPSC 320, MATH 1XX 
+  courses: ["CPSC121", "CPSC221", "CPSC320", "MATH1XX"] 
   email: spornleo@gmail.com
   rates: $40/hr
   availability: Flexible
 
 - name: Michael Allan
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 121, CPSC 210, CPSC 213, CPSC 221
+  courses: ["CPSC110", "CPSC121", "CPSC210", "CPSC213", "CPSC221"]
   email: mb.allan@ymail.com
   availability: After 2 PM on weekdays, anytime on weekends
   bio: |
@@ -58,14 +58,14 @@
 
 - name: Roceley Yuo
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 210, CPSC 213, CPSC 310, CPSC 304, CPSC 313, CPSC 415
+  courses: ["CPSC110", "CPSC210", "CPSC213", "CPSC310", "CPSC304", "CPSC313", "CPSC415"]
   email: roceleylaw@gmail.com
   availability: Full day
   rates: $40/hr
 
 - name: Kat Ye
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 210, CPSC 221, CPSC 214, CPSC 304, CPSC 310, CPSC 313, CPSC 320, CPSC 340 
+  courses: ["CPSC110", "CPSC210", "CPSC221", "CPSC214", "CPSC304", "CPSC310", "CPSC313", "CPSC320", "CPSC340"] 
   email: 7111605ying@gmail.com
   rates: $45/hr
   bio: CPSC graduated student
@@ -73,7 +73,7 @@
 
 - name: Frank Hui
   lastmod: 2021-11-21
-  courses: CPSC 121, CPSC 210, MATH 100, MATH 101, MATH 200, MATH 221
+  courses: ["CPSC121", "CPSC210", "MATH100", "MATH101", "MATH200", "MATH221"]
   email: huifrank@live.com
   rates: $30/hr
   bio: |
@@ -82,19 +82,19 @@
 
 - name: Daocheng Wang
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 121
+  courses: ["CPSC110", "CPSC121"]
   email: wangdc2010@gmail.com
   rates: $70/hr
 
 - name: Vancoding
   lastmod: 2021-11-21
-  courses: CPSC 100, CPSC 103, CPSC 107, CPSC 110, CPSC 121, CPSC 210, CPSC 221, CPSC 213, CPSC 302, CPSC 304, CPSC 310, CPSC 313, CPSC 314, CPSC 317, CPSC 320, CPSC 322, CPSC 330, CPSC 340, CPSC 424, CPSC 425
+  courses: ["CPSC100", "CPSC103", "CPSC107", "CPSC110", "CPSC121", "CPSC210", "CPSC221", "CPSC213", "CPSC302", "CPSC304", "CPSC310", "CPSC313", "CPSC314", "CPSC317", "CPSC320", "CPSC322", "CPSC330", "CPSC340", "CPSC424", "CPSC425"]
   email: vancodingcs@gmail.com
   rates: $10/hr
 
 - name: Wayne
   lastmod: 2021-11-21
-  courses: CPSC 110, CPSC 121, CPSC 210, CPSC 213, CPSC 221, CPSC 310, CPSC 320, CPSC 314, CPSC 304, CPSC 425
+  courses: ["CPSC110", "CPSC121", "CPSC210", "CPSC213", "CPSC221", "CPSC310", "CPSC320", "CPSC314", "CPSC304", "CPSC425"]
   email: kathyye26@yahoo.com
   rates: $50/hr
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -39,7 +39,7 @@
   translation: "Last updated: "
 
 - id: courses
-  translation: "Courses: {{ .courses }}"
+  translation: 'Courses: '
 
 - id: availability
   translation: "Availability: {{ .availability }}"

--- a/layouts/shortcodes/tutors.html
+++ b/layouts/shortcodes/tutors.html
@@ -8,9 +8,29 @@
 {{ $endDate := ($startDate.AddDate 1 0 0).Format "2006" }}
 <h2>{{ i18n "verifiedTutors" (dict "start" $startYear "end" $endDate) }}</h2>
 
+{{/* building list of unique course codes */}}
+{{ $scratch := newScratch }}
+{{ range .Site.Data.tutor }}
+    {{ $scratch.Add "courseCodes" .courses }}
+{{ end }}
+
+{{ $scratch.Set "courseCodes" (sort (uniq ($scratch.Get "courseCodes"))) }}
+
+<div class="dropdown">
+  <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Filter courses
+  </button>
+  <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+    <a class="dropdown-item" id="tutors-show-all" onClick="showAll()" >Show All</a>
+    {{ range ($scratch.Get "courseCodes") }}
+        <a class="dropdown-item" id="tutors-{{ . }}" onClick="showId({{ . }})">{{ . }}</a>
+    {{ end }}
+  </div>
+</div><br>
+
 {{ range sort .Site.Data.tutor ".name" "asc" }}
-    <div class="card w-100 mb-3">
-        <div class="card-body {{ range (.courses) }}{{ . }} {{ end }}">
+    <div class="card w-100 mb-3 {{ range (.courses) }}{{ . }} {{ end }} tutor">
+        <div class="card-body">
             <h5 class="card-title">{{ .name }}</h5>
             <p class="card-text mb-2">{{ i18n "courses" . | markdownify }} {{ delimit .courses ", " }}</p>
             {{ if or (.availability) (.rates) (.bio) }}
@@ -31,3 +51,21 @@
         </div>
     </div>
 {{ end }}
+
+<script>
+const showAll = () => {
+        document.querySelectorAll('.tutor').forEach((element) => {element.style.display = "block";});
+}
+
+const showId = (id) => {
+    document.querySelectorAll('.tutor').forEach((element) => {element.style.display = "none";});
+    document.querySelectorAll(`.${id}`).forEach((element) => {element.style.display = "block";});
+}
+</script>
+
+<style>
+.dropdown-item {
+    cursor: pointer;
+}
+</style>
+ 

--- a/layouts/shortcodes/tutors.html
+++ b/layouts/shortcodes/tutors.html
@@ -10,9 +10,9 @@
 
 {{ range sort .Site.Data.tutor ".name" "asc" }}
     <div class="card w-100 mb-3">
-        <div class="card-body">
+        <div class="card-body {{ range (.courses) }}{{ . }} {{ end }}">
             <h5 class="card-title">{{ .name }}</h5>
-            <p class="card-text mb-2">{{ i18n "courses" . | markdownify }}</p>
+            <p class="card-text mb-2">{{ i18n "courses" . | markdownify }} {{ delimit .courses ", " }}</p>
             {{ if or (.availability) (.rates) (.bio) }}
             <details class="mb-2"><summary>More</summary>
                 {{ if .availability }}

--- a/layouts/shortcodes/tutors.html
+++ b/layouts/shortcodes/tutors.html
@@ -18,7 +18,7 @@
 
 <div class="dropdown">
   <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    Filter courses
+    Filter by course
   </button>
   <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
     <a class="dropdown-item" id="tutors-show-all" onClick="showAll()" >Show All</a>
@@ -54,15 +54,18 @@
 
 <script>
 const showAll = () => {
-        document.querySelectorAll('.tutor').forEach((element) => {element.style.display = "block";});
+    document.querySelectorAll('.tutor').forEach((element) => {element.style.display = "block";});
+    document.querySelectorAll('#dropdownMenuButton').forEach((element) => {element.innerText = "Filter by course"});
 }
 
 const showId = (id) => {
     document.querySelectorAll('.tutor').forEach((element) => {element.style.display = "none";});
     document.querySelectorAll(`.${id}`).forEach((element) => {element.style.display = "block";});
+    document.querySelectorAll('#dropdownMenuButton').forEach((element) => {element.innerText = id});
 }
 </script>
 
+<!-- for cosmetic purposes -->
 <style>
 .dropdown-item {
     cursor: pointer;


### PR DESCRIPTION
This PR adds filtering by course to the [tutors](https://ubccsss.org/services/tutor/) page (#12, and our conversation on Zoom):
- Restructured the `data/tutor.yaml` to use a YAML list of course strings (with the slight side effect that courses are now 'AAAABBB' codes instead of 'AAAA BBB'
- Built dropdown from list of unique courses over all tutors - this will update by itself on build if we add new tutors in the future
- Added a bit of JS to toggle visibility of cards based on their course codes, which are stored as classes (why I needed the course codes to be all one word)