### PR TITLE
Updated ubcgrades API endpoint

### DIFF
--- a/assets/js/grades-api.js
+++ b/assets/js/grades-api.js
@@ -1,26 +1,27 @@
-(function() {
-  function loadGrades(subject, course) {
-    return fetch(`https://ubcgrades.com/api/course-profile/${subject}/${course}`)
-      .then(res => res.json());
+(async () => {
+  async function loadGrades(subject, course) {
+    const res = await fetch(`https://ubcgrades.com/api/v2/course-statistics/UBCV/${subject}/${course}`);
+    return await res.json();
   }
+
   function addDescription(list, term, details) {
     const dt = document.createElement('dt');
     const dd = document.createElement('dd');
-    dt.className = 'col-sm-3'
+    dt.className = 'col-sm-3';
     dt.textContent = term;
-    dd.className = 'col-sm-9'
+    dd.className = 'col-sm-9';
     dd.textContent = details + '%';
     list.append(dt, dd);
   }
-  document.querySelectorAll('.grades-api').forEach(function(gradesEl) {
-    console.log(gradesEl);
-    loadGrades(gradesEl.dataset.subject, gradesEl.dataset.course).then(json => {
-      const fragment = document.createDocumentFragment();
-      addDescription(fragment, 'Average', json.average);
-      addDescription(fragment, 'Highest Grade', json.high);
-      addDescription(fragment, 'Lowest Grade', json.low);
-      addDescription(fragment, 'Percentage passed', json.pass_percent);
-      gradesEl.append(fragment);
-    });
-  });
+
+  const gradesEl = document.getElementsByClassName('grades-api')[0];
+  const grades = await loadGrades(gradesEl.dataset.subject, gradesEl.dataset.course);
+  const { average, average_past_5_yrs, max_course_avg, min_course_avg, stdev } = grades;
+  const fragment = document.createDocumentFragment();
+  addDescription(fragment, 'Average (all time)', average);
+  addDescription(fragment, 'Average (past 5 years)', average_past_5_yrs);
+  addDescription(fragment, 'Highest Grade', max_course_avg);
+  addDescription(fragment, 'Lowest Grade', min_course_avg);
+  addDescription(fragment, 'Standard Deviation', stdev);
+  gradesEl.append(fragment);
 })();

--- a/assets/js/grades-api.js
+++ b/assets/js/grades-api.js
@@ -20,8 +20,8 @@
   const fragment = document.createDocumentFragment();
   addDescription(fragment, 'Average (all time)', average);
   addDescription(fragment, 'Average (past 5 years)', average_past_5_yrs);
-  addDescription(fragment, 'Highest Grade', max_course_avg);
-  addDescription(fragment, 'Lowest Grade', min_course_avg);
+  addDescription(fragment, 'Highest Average', max_course_avg);
+  addDescription(fragment, 'Lowest Average', min_course_avg);
   addDescription(fragment, 'Standard Deviation', stdev);
   gradesEl.append(fragment);
 })();

--- a/assets/js/grades-api.js
+++ b/assets/js/grades-api.js
@@ -10,7 +10,7 @@
     dt.className = 'col-sm-3';
     dt.textContent = term;
     dd.className = 'col-sm-9';
-    dd.textContent = details + '%';
+    dd.textContent = details.toFixed(2) + '%';
     list.append(dt, dd);
   }
 

--- a/layouts/partials/course/grades.html
+++ b/layouts/partials/course/grades.html
@@ -3,7 +3,7 @@
 {{ $subject := index $parts 0 | upper }}
 {{ $course := index $parts 1 }}
 <h3>Historical grade information</h3>
-<dl class="grades-api row" data-subject="{{ $subject }}" data-course="{{ $course }}"></dl>
+<dl class="grades-api row mb-2" data-subject="{{ $subject }}" data-course="{{ $course }}"></dl>
 <p class="grades-api__attribution">
   <small>
     Grades information from


### PR DESCRIPTION
I updated the API endpoint to work with the new version. 

new endpoint example: [https://ubcgrades.com/api/v2/course-statistics/UBCV/CPSC/221](https://ubcgrades.com/api/v2/course-statistics/UBCV/CPSC/221)

It doesn't work locally due to CORS, but it should work on the live version (maybe).

![image](https://user-images.githubusercontent.com/39626451/150628472-d40960b1-82ae-48cc-b731-906b2d71bb07.png)

close #109