### PR TITLE
Add post template overrides

### DIFF
--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,0 +1,16 @@
+---
+# The title of the post
+title: "{{ delimit (split .Name "-" | after 3) " " | title }}"
+# Tags that apply to the post
+tags: []
+categories: []
+# Name of the author (you)
+author: TODO Your name
+# Images associated to this post. Used for banner.
+images:
+  - /files/TODO-banner.png
+---
+
+![](/files/TODO-banner.png)
+
+TODO write description here

--- a/content/posts/2022-01-11-recap-2021.md
+++ b/content/posts/2022-01-11-recap-2021.md
@@ -7,7 +7,7 @@ categories: [services]
 images:
     - /files/2022-01-11-Recap-2021.png
 ---
-\
+
 ![](/files/2022-01-11-Recap-2021.png)
 
 Hello CS folks!

--- a/layouts/posts/content.html
+++ b/layouts/posts/content.html
@@ -1,0 +1,10 @@
+<article class="blog-post">
+    <header>
+        {{ partial "post-title" . }}
+        {{ partial "post-date" . }}
+        {{ partial "post-tags" . }}
+        {{ partial "post-categories" . }}
+        <br>
+    </header>
+    {{ .Content }}
+</article>


### PR DESCRIPTION
This PR adds post template overrides, so that the rendering of posts are exactly the same as events (#124):
- Adds an `archetypes/posts.md` so that whenever `hugo new posts/20XX-XX-XX-XXXX.md` is run, a template is auto-filled. This template was largely copied from the `events` template, and contains fields for author, tags, and categories. Previously, these fields weren't present, and needed to be manually edited.
- Adds a `layouts/posts/content.html` for the summaries that we use on the main homepage. This is also largely copied from the `events` template. The main difference here from the previous behaviour is a linebreak and some additional attribution information.

(This PR also touches the 2021 recap post to remove the unnecessary linebreak - the layouts should handle that now!)