### PR TITLE
Add all missing courses

### DIFF
--- a/content/services/courses/cpsc-100.md
+++ b/content/services/courses/cpsc-100.md
@@ -1,7 +1,6 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computational Thinking
 layout: course
 ---
 
 No reviews yet - please add yours below!
-

--- a/content/services/courses/cpsc-103.md
+++ b/content/services/courses/cpsc-103.md
@@ -1,7 +1,6 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Introduction to Systematic Program Design
 layout: course
 ---
 
 No reviews yet - please add yours below!
-

--- a/content/services/courses/cpsc-107.md
+++ b/content/services/courses/cpsc-107.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Systematic Program Design
 layout: course
 ---
 

--- a/content/services/courses/cpsc-110.md
+++ b/content/services/courses/cpsc-110.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computation, Programs, and Programming
 layout: course
 ---
 

--- a/content/services/courses/cpsc-121.md
+++ b/content/services/courses/cpsc-121.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Models of Computation
 layout: course
 ---
 

--- a/content/services/courses/cpsc-203.md
+++ b/content/services/courses/cpsc-203.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Programming, Problem Solving, and Algorithms
 layout: course
 ---
 

--- a/content/services/courses/cpsc-210.md
+++ b/content/services/courses/cpsc-210.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Software Construction
 layout: course
 ---
 

--- a/content/services/courses/cpsc-213.md
+++ b/content/services/courses/cpsc-213.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Introduction to Computer Systems
 layout: course
 ---
 

--- a/content/services/courses/cpsc-259.md
+++ b/content/services/courses/cpsc-259.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Data Structures and Algorithms for Electrical Engineers
 layout: course
 ---
 

--- a/content/services/courses/cpsc-298.md
+++ b/content/services/courses/cpsc-298.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Co-operative Work Placement I (CS Co-ops)
 layout: course
 ---
 

--- a/content/services/courses/cpsc-303.md
+++ b/content/services/courses/cpsc-303.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Numerical Approximation and Discretization
 layout: course
 ---
 

--- a/content/services/courses/cpsc-310.md
+++ b/content/services/courses/cpsc-310.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Introduction to Software Engineering
 layout: course
 ---
 

--- a/content/services/courses/cpsc-313.md
+++ b/content/services/courses/cpsc-313.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computer Hardware and Operating Systems
 layout: course
 ---
 

--- a/content/services/courses/cpsc-314.md
+++ b/content/services/courses/cpsc-314.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computer Graphics
 layout: course
 ---
 

--- a/content/services/courses/cpsc-320.md
+++ b/content/services/courses/cpsc-320.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Intermediate Algorithm Design and Analysis
 layout: course
 ---
 

--- a/content/services/courses/cpsc-322.md
+++ b/content/services/courses/cpsc-322.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Introduction to Artificial Intelligence
 layout: course
 ---
 

--- a/content/services/courses/cpsc-330.md
+++ b/content/services/courses/cpsc-330.md
@@ -1,5 +1,5 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Applied Machine Learning
 layout: course
 ---
 

--- a/content/services/courses/cpsc-340.md
+++ b/content/services/courses/cpsc-340.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Machine Learning and Data Mining 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-344.md
+++ b/content/services/courses/cpsc-344.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Introduction to Human Computer Interaction Methods 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-349.md
+++ b/content/services/courses/cpsc-349.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Honours Research Seminar 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-368.md
+++ b/content/services/courses/cpsc-368.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Databases in Data Science 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-404.md
+++ b/content/services/courses/cpsc-404.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Advanced Relational Databases 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-410.md
+++ b/content/services/courses/cpsc-410.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Advanced Software Engineering
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-417.md
+++ b/content/services/courses/cpsc-417.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computer Networking 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-420.md
+++ b/content/services/courses/cpsc-420.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Advanced Algorithms Design and Analysis 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-422.md
+++ b/content/services/courses/cpsc-422.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Intelligent Systems 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-426.md
+++ b/content/services/courses/cpsc-426.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computer Animation 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-427.md
+++ b/content/services/courses/cpsc-427.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Video Game Programming 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-430.md
+++ b/content/services/courses/cpsc-430.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computers and Society 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-436.md
+++ b/content/services/courses/cpsc-436.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Computer Science (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-440.md
+++ b/content/services/courses/cpsc-440.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Advanced Machine Learning 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-444.md
+++ b/content/services/courses/cpsc-444.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Advanced Methods for Human Computer Interaction 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-445.md
+++ b/content/services/courses/cpsc-445.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Algorithms in Bioinformatics 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-448.md
+++ b/content/services/courses/cpsc-448.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Directed Studies in Computer Science (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-449.md
+++ b/content/services/courses/cpsc-449.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Honours Thesis 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-491.md
+++ b/content/services/courses/cpsc-491.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Interactive Digital Media Practicum 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-501.md
+++ b/content/services/courses/cpsc-501.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Theory of Automata, Formal Languages and Computability 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-503.md
+++ b/content/services/courses/cpsc-503.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computational Linguistics I 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-509.md
+++ b/content/services/courses/cpsc-509.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Programming Language Principles 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-513.md
+++ b/content/services/courses/cpsc-513.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Introduction to Formal Verification and Analysis 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-524.md
+++ b/content/services/courses/cpsc-524.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Computer Graphics - Modelling 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-530.md
+++ b/content/services/courses/cpsc-530.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Information Processing 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-532.md
+++ b/content/services/courses/cpsc-532.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Artificial Intelligence (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-533.md
+++ b/content/services/courses/cpsc-533.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Computer Graphics (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-534.md
+++ b/content/services/courses/cpsc-534.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Topics in Data Management 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-536.md
+++ b/content/services/courses/cpsc-536.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Algorithms and Complexity (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-538.md
+++ b/content/services/courses/cpsc-538.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Computer Systems (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-539.md
+++ b/content/services/courses/cpsc-539.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Programming Languages 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-540.md
+++ b/content/services/courses/cpsc-540.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Machine Learning 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-543.md
+++ b/content/services/courses/cpsc-543.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Physical User Interface Design and Evaluation 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-544.md
+++ b/content/services/courses/cpsc-544.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Human Computer Interaction 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-545.md
+++ b/content/services/courses/cpsc-545.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Algorithms for Bioinformatics 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-547.md
+++ b/content/services/courses/cpsc-547.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: 	Information Visualization 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-549.md
+++ b/content/services/courses/cpsc-549.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Master's Thesis (All)
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-554.md
+++ b/content/services/courses/cpsc-554.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Topics in Human-Computer Interaction 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-589.md
+++ b/content/services/courses/cpsc-589.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: M.Sc. Major Essay 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 

--- a/content/services/courses/cpsc-649.md
+++ b/content/services/courses/cpsc-649.md
@@ -1,7 +1,8 @@
 ---
-title: Numerical Computation for Algebraic Problems
+title: Doctoral Dissertation 
 layout: course
 ---
 
 No reviews yet - please add yours below!
+
 


### PR DESCRIPTION
This PR adds empty pages for all missing courses (#131).
- Right now, empty pages just have a message to check back later or add a review via the form below. Let me know if you'd like this message to be changed to something else!
- I included all the courses I found with a CPSC course code, including all the graduate courses and thesis work courses. I thought it might be useful to share those upper-level experiences and have a form open for them, but I'm also not sure if many people would submit or browse them.

Let me know if there are any other changes you'd like me to make!