### PR TITLE
Add mobile styling fixes for Programmable Search

### DIFF
--- a/layouts/partials/search-box.html
+++ b/layouts/partials/search-box.html
@@ -2,29 +2,27 @@
 <div class="gcse-search"></div>
 
 <style>
-    @media only screen and (max-width: 768px) {
-        .gsc-input-box {
-            padding-top: 0;
-            padding-bottom: 5px;
-            border-radius: 8px 0 0 8px;
-        }
-        .gsc-search-button-v2 {
-            width: auto;
-            padding: 11px 10px;
-            margin: 0;
-            border-radius: 0;
-            border-top-right-radius: 8px;
-            border-bottom-right-radius: 8px;
-        }
-        .gsc-search-box-tools .gsc-search-box .gsc-input {
-            padding: 0;
-        }
-        .gsc-input-box table {
-            height: 100%;
-        }
-        .gsc-search-button-v2 svg {
-            height: auto;
-            width: 16px;
-        }
+    .gsc-input-box {
+        padding-top: 3px;
+        padding-bottom: 2px;
+        border-radius: 8px 0 0 8px;
+    }
+    .gsc-search-button-v2 {
+        width: auto;
+        padding: 11px 10px;
+        margin: 0;
+        border-radius: 0;
+        border-top-right-radius: 8px;
+        border-bottom-right-radius: 8px;
+    }
+    .gsc-search-box-tools .gsc-search-box .gsc-input {
+        padding: 0;
+    }
+    .gsc-input-box table {
+        height: 100%;
+    }
+    .gsc-search-button-v2 svg {
+        height: auto;
+        width: 16px;
     }
 </style>

--- a/layouts/partials/search-box.html
+++ b/layouts/partials/search-box.html
@@ -1,2 +1,30 @@
 <script async src="{{ site.Params.gcseURL }}"></script>
 <div class="gcse-search"></div>
+
+<style>
+    @media only screen and (max-width: 768px) {
+        .gsc-input-box {
+            padding-top: 0;
+            padding-bottom: 5px;
+            border-radius: 8px 0 0 8px;
+        }
+        .gsc-search-button-v2 {
+            width: auto;
+            padding: 11px 10px;
+            margin: 0;
+            border-radius: 0;
+            border-top-right-radius: 8px;
+            border-bottom-right-radius: 8px;
+        }
+        .gsc-search-box-tools .gsc-search-box .gsc-input {
+            padding: 0;
+        }
+        .gsc-input-box table {
+            height: 100%;
+        }
+        .gsc-search-button-v2 svg {
+            height: auto;
+            width: 16px;
+        }
+    }
+</style>


### PR DESCRIPTION
This PR fixes some mobile-specific display issues (#149):
- Google Programmable Search seems to use `mobile+en.css` styles when it detects certain user agents (maybe why this didn't come up in testing)
- The issues Asad brought up seem to be a problem with Google's CSS somewhere, so I applied override styles to what I *think* that it was supposed to look like
- I applied this to all viewports <768px wide, so that we have consistent display when on a smaller Chrome or desktop window, and also when on an actual mobile device. The mobile display style now no longer depends on Google's mobile CSS.

I tested this just with my iPhone so this might not work entirely on Android - please let me know if there are any fixes to be made or anything I missed!