### PR TITLE
Add past officers (missing info, used what I could find)

### DIFF
--- a/content/about/team/officers/2018.md
+++ b/content/about/team/officers/2018.md
@@ -1,0 +1,79 @@
+---
+title: Officers—2018–2019 
+date: 2018-08-31
+aliases:
+  - /club/about/officers/2018
+---
+
+### Leslie Min
+
+Office Manager
+
+___
+
+
+### Bronwyn Damm
+
+Office Manager
+
+___
+
+
+### Aidan Perras
+
+Office Manager
+
+___
+
+
+### Subi
+
+Supply Run Officer
+
+___
+
+
+### Stevens Qiu
+
+Financial Officer
+
+___
+
+
+### Colin Chen
+
+Office Manager
+
+___
+
+
+### Kevin Wu
+
+Office Manager
+
+___
+
+
+### Andrew Ouyang
+
+Office Manager
+
+___
+
+
+### Jamie Polintan
+
+Financial Officer
+
+___
+
+
+### Dante Cerron
+
+Office Manager
+
+___
+
+### Dmitry Narkevich
+
+Webmaster

--- a/content/about/team/officers/2021.md
+++ b/content/about/team/officers/2021.md
@@ -1,8 +1,8 @@
 ---
-title: Officers
-date: 2018-08-31
+title: Officers—2021–2022 
+date: 2021-01-01
 aliases:
-  - /club/about/officers
+  - /club/about/officers/2021
 ---
 
 ### Xiaoyang Zhang
@@ -28,6 +28,7 @@ Communications Officer
 Communications Officer
 
 ---
+
 ### Elliot Qi
 
 External Affairs Officer

--- a/content/about/team/officers/2022.md
+++ b/content/about/team/officers/2022.md
@@ -1,0 +1,34 @@
+---
+title: Current Officers—2022–2023 
+date: 2022-06-16
+aliases:
+  - /club/about/officers
+---
+
+### Jeremy Qiao
+
+External Officer
+
+---
+
+### Taryn Wou
+
+External Officer
+
+---
+
+### Emilie Ma
+
+Webmaster
+
+---
+
+### Asad Dhorajiwala
+
+Webmaster
+
+---
+
+### Ramit Kataria
+
+Webmaster

--- a/content/about/team/officers/_index.md
+++ b/content/about/team/officers/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Officers
-date: 2021-12-05
+date: 2022-06-16
 layout: current-officers
 ---


### PR DESCRIPTION
This PR adds pages for officers from past school years, based on the Git history of `content/about/team/officers.md`. This history only went back to 2018, and is missing the 2019-2020 + 2020-2021 school years. 

This should be merged in after Ramit's PR #194, and depends on [#6](https://github.com/ubccsss/hugo-bootstrap-5/pull/6) here. 

Please let me know if anyone has past lists of officers, and we can fill in more pages!