### PR TITLE
Add Linktree

### DIFF
--- a/data/social.yml
+++ b/data/social.yml
@@ -1,5 +1,8 @@
 # Items in the "Elsewhere" section of the sidebar.
 
+- title: Linktree
+  icon: /modules/linktree.svg
+  link: https://linktr.ee/ubc_csss
 - title: Facebook
   icon: /modules/facebook.svg
   link: https://www.facebook.com/ubccsss
@@ -18,3 +21,4 @@
 - title: RSS
   icon: /modules/rss.svg
   link: /index.xml
+

--- a/static/modules/linktree.svg
+++ b/static/modules/linktree.svg
@@ -1,0 +1,22 @@
+<svg width="14" height="14" xmlns="http://www.w3.org/2000/svg" xmlns:undefined="http://www.inkscape.org/namespaces/inkscape" xml:space="preserve" version="1.0">
+
+ <g>
+  <title>Layer 1</title>
+  <g stroke="null"   id="layer1">
+   <g stroke="null" transform="matrix(0.00719769 0 0 0.00719769 47.9002 181.391)" id="svg_4">
+    <g stroke="null" transform="matrix(0.857143 0 0 0.857143 8 306)" id="svg_3">
+     <path stroke="null" fill="#212529" clip-rule="evenodd" fill-rule="evenodd" d="m-6897.57078,-25864.53929l236.4,0l0,531.3l-236.4,0l0,-531.3" class="st0" id="svg_1"/>
+     <path stroke="null" fill="#212529" clip-rule="evenodd" fill-rule="evenodd" d="m-7444.17078,-26408.43929l401.7,0l-286,-270.7l157.6,-160.6l272.1,278.3l0,-396l236.4,0l0,395.9l272,-278.3l157.6,160.6l-286,270.7l401.8,0l0,223.9l-404.3,0l287.3,278.3l-157.6,156.9l-390.3,-390.9l-390.3,390.9l-157.6,-156.9l287.3,-278.3l-404.2,0l0,-223.8l2.5,0" class="st0" id="svg_2"/>
+    </g>
+   </g>
+  </g>
+  <g stroke="null"   id="svg_10">
+   <g stroke="null" transform="matrix(0.0102109 0 0 0.00989492 67.3226 218.77)" id="svg_9">
+    <g stroke="null" transform="matrix(0.857143 0 0 0.857143 8 306)" id="svg_8">
+     <path stroke="null" fill="#212529" clip-rule="evenodd" fill-rule="evenodd" d="m-7012.0516,-25046.02016l236.4,0l0,531.3l-236.4,0l0,-531.3" class="st0" id="svg_6"/>
+     <path stroke="null" fill="#212529" clip-rule="evenodd" fill-rule="evenodd" d="m-7558.6516,-25589.92016l401.7,0l-286,-270.7l157.6,-160.6l272.1,278.3l0,-396l236.4,0l0,395.9l272,-278.3l157.6,160.6l-286,270.7l401.8,0l0,223.9l-404.3,0l287.3,278.3l-157.6,156.9l-390.3,-390.9l-390.3,390.9l-157.6,-156.9l287.3,-278.3l-404.2,0l0,-223.8l2.5,0" class="st0" id="svg_7"/>
+    </g>
+   </g>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
This PR adds the Linktree to the top of the elsewhere section in the sidebar as discussed on Slack.