### PR TITLE
Add course descriptions

### DIFF
--- a/content/services/courses/cpsc-100.md
+++ b/content/services/courses/cpsc-100.md
@@ -1,5 +1,6 @@
 ---
 title: Computational Thinking
 layout: course
+description: Meaning and impact of computational thinking. Solving problems using computational thinking, testing, debugging. How computers work. No prior computing experience required. Not for students with existing credit for or exemption from CPSC 107, CPSC 110 or APSC 160.
 ---
 

--- a/content/services/courses/cpsc-103.md
+++ b/content/services/courses/cpsc-103.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Systematic Program Design
 layout: course
+description: Computation as a tool for systematic problem solving in non-computer-science disciplines. Introductory programming skills. Not for credit for students who have credit for, or exemption from, or are concurrently taking CPSC 110 or APSC 160. No programming experience expected.
 ---
 

--- a/content/services/courses/cpsc-107.md
+++ b/content/services/courses/cpsc-107.md
@@ -1,5 +1,6 @@
 ---
 title: Systematic Program Design
 layout: course
+description: Fundamental computation and program structures. Continuing systematic program design from CPSC 103.
 ---
 

--- a/content/services/courses/cpsc-110.md
+++ b/content/services/courses/cpsc-110.md
@@ -1,5 +1,6 @@
 ---
 title: Computation, Programs, and Programming
 layout: course
+description: Fundamental program and computation structures. Introductory programming skills. Computation as a tool for information processing, simulation and modelling, and interacting with the world.
 ---
 

--- a/content/services/courses/cpsc-121.md
+++ b/content/services/courses/cpsc-121.md
@@ -1,5 +1,6 @@
 ---
 title: Models of Computation
 layout: course
+description: Physical and mathematical structures of computation. Boolean algebra and combinations logic circuits; proof techniques; functions and sequential circuits; sets and relations; finite state machines; sequential instruction execution.
 ---
 

--- a/content/services/courses/cpsc-203.md
+++ b/content/services/courses/cpsc-203.md
@@ -1,4 +1,5 @@
 ---
 title: Programming, Problem Solving, and Algorithms
 layout: course
+description: Analysis of increasingly complex algorithmic problems, using a modern programming language and a variety of approaches. Problem decomposition and abstraction guide explorations of topics from applied algorithms, for example Voronoi Diagrams, Markov Chains, Bin Packing, and Graph Search. Not for students with credit for, or currently enrolled in, CPSC 210 or CPEN 221.
 ---

--- a/content/services/courses/cpsc-210.md
+++ b/content/services/courses/cpsc-210.md
@@ -1,5 +1,6 @@
 ---
 title: Software Construction
 layout: course
+description: Design, development, and analysis of robust software components. Topics such as software design, computational models, data structures, debugging, and testing.
 ---
 

--- a/content/services/courses/cpsc-213.md
+++ b/content/services/courses/cpsc-213.md
@@ -1,4 +1,5 @@
 ---
 title: Introduction to Computer Systems
 layout: course
+description: Software architecture, operating systems, and I/O architectures. Relationships between application software, operating systems, and computing hardware; critical sections, deadlock avoidance, and performance; principles and operation of disks and networks.
 ---

--- a/content/services/courses/cpsc-221.md
+++ b/content/services/courses/cpsc-221.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Algorithms and Data Structures
 layout: course
+description: Design and analysis of basic algorithms and data structures; algorithm analysis methods, searching and sorting algorithms, basic data structures, graphs and concurrency.
 ---
 

--- a/content/services/courses/cpsc-259.md
+++ b/content/services/courses/cpsc-259.md
@@ -1,5 +1,6 @@
 ---
 title: Data Structures and Algorithms for Electrical Engineers
 layout: course
+description: Advanced procedural programming. Fundamental algorithms for sorting and searching. Data structures including lists, trees, and hash tables. Introduction to scripting languages and file input/output.
 ---
 

--- a/content/services/courses/cpsc-298.md
+++ b/content/services/courses/cpsc-298.md
@@ -1,5 +1,6 @@
 ---
 title: Co-operative Work Placement I (CS Co-ops)
 layout: course
+description: Approved and supervised technical work experience in the computing industry for a minimum of 3.5 months. Normally taken during Winter Session of second year. Technical report required. Restricted to students admitted to the Co-operative Education Program in Computer Science.
 ---
 

--- a/content/services/courses/cpsc-302.md
+++ b/content/services/courses/cpsc-302.md
@@ -1,5 +1,6 @@
 ---
 title: Numerical Computation for Algebraic Problems
 layout: course
+description: Numerical techniques for basic mathematical processes involving no discretization, and their analysis. Solution of linear systems, including analysis of round-off errors; norms and condition number; introduction to iterative techniques in linear algebra, including eigenvalue problems; solution to nonlinear equations.
 ---
 

--- a/content/services/courses/cpsc-303.md
+++ b/content/services/courses/cpsc-303.md
@@ -1,5 +1,6 @@
 ---
 title: Numerical Approximation and Discretization
 layout: course
+description: Numerical techniques for basic mathematical processes involving discretization, and their analysis. Interpolation and approximation, including splines and least squares data fitting; numerical differentiation and integration; introduction to numerical initial value ordinary differential equations.
 ---
 

--- a/content/services/courses/cpsc-304.md
+++ b/content/services/courses/cpsc-304.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Relational Databases
 layout: course
+description: Overview of database systems, ER models, logical database design and normalization, formal relational query languages, SQL and other commercial languages,data warehouses, special topics.
 ---
 

--- a/content/services/courses/cpsc-310.md
+++ b/content/services/courses/cpsc-310.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Software Engineering
 layout: course
+description: Specification, design, validation, evolution and construction of modern software systems, within the context of socially and professionally relevant domains such as ethics, intellectual property, and information security.
 ---
 

--- a/content/services/courses/cpsc-311.md
+++ b/content/services/courses/cpsc-311.md
@@ -1,4 +1,5 @@
 ---
 title: Definition of Programming Languages
 layout: course
+description: Comparative study of advanced programming language features. Statement types, data types, variable binding, parameter passing mechanisms. Methods for syntactic and semantic description of programming languages.
 ---

--- a/content/services/courses/cpsc-312.md
+++ b/content/services/courses/cpsc-312.md
@@ -1,5 +1,6 @@
 ---
 title: Functional and Logic Programming
 layout: course
+description: Principles of symbolic computing, using languages based upon first-order logic and the lambda calculus. Algorithms for implementing such languages. Applications to artificial intelligence and knowledge representation.
 ---
 

--- a/content/services/courses/cpsc-313.md
+++ b/content/services/courses/cpsc-313.md
@@ -1,5 +1,6 @@
 ---
 title: Computer Hardware and Operating Systems
 layout: course
+description: Instruction sets, pipelining, code optimization, caching, virtual memory management, dynamically linked libraries, exception processing, execution time of programs.
 ---
 

--- a/content/services/courses/cpsc-314.md
+++ b/content/services/courses/cpsc-314.md
@@ -1,5 +1,6 @@
 ---
 title: Computer Graphics
 layout: course
+description: Human vision and colour; geometric transformations; algorithms for 2-D and 3-D graphics; hardware and system architectures; shading and lighting; animation.
 ---
 

--- a/content/services/courses/cpsc-317.md
+++ b/content/services/courses/cpsc-317.md
@@ -1,5 +1,6 @@
 ---
 title: Internet Computing
 layout: course
+description: Computer networking, basic communication protocols, network infrastructure and routing. Common application-level protocols and principles associated with developing distributed applications.
 ---
 

--- a/content/services/courses/cpsc-319.md
+++ b/content/services/courses/cpsc-319.md
@@ -1,4 +1,5 @@
 ---
 title: Software Engineering Project
 layout: course
+description: The design, implementation, and test of a large software system, using a team approach.
 ---

--- a/content/services/courses/cpsc-320.md
+++ b/content/services/courses/cpsc-320.md
@@ -1,5 +1,7 @@
 ---
 title: Intermediate Algorithm Design and Analysis
 layout: course
+description: >
+  Systematic study of basic concepts and techniques in the design and analysis of algorithms, illustrated from various problem areas. Topics include: models of computation; choice of data structures; graph-theoretic, algebraic, and text processing algorithms.
 ---
 

--- a/content/services/courses/cpsc-322.md
+++ b/content/services/courses/cpsc-322.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Artificial Intelligence
 layout: course
+description: Problem-solving and planning; state/action models and graph searching. Natural language understanding Computational vision. Applications of artificial intelligence.
 ---
 

--- a/content/services/courses/cpsc-330.md
+++ b/content/services/courses/cpsc-330.md
@@ -1,5 +1,6 @@
 ---
 title: Applied Machine Learning
 layout: course
+description: Application of machine learning tools, with an emphasis on solving practical problems. Data cleaning, feature extraction, supervised and unsupervised machine learning, reproducible workflows, and communicating results.
 ---
 

--- a/content/services/courses/cpsc-340.md
+++ b/content/services/courses/cpsc-340.md
@@ -1,5 +1,6 @@
 ---
 title: Machine Learning and Data Mining
 layout: course
+description: Models of algorithms for dimensionality reduction, nonlinear regression, classification, clustering and unsupervised learning; applications to computer graphics, computer games, bio-informatics, information retrieval, e-commerce, databases, computer vision and artificial intelligence.
 ---
 

--- a/content/services/courses/cpsc-344.md
+++ b/content/services/courses/cpsc-344.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Human Computer Interaction Methods
 layout: course
+description: Basic tools and techniques, teaching a systematic approach to interface design, task analysis, analytic and empirical evaluation methods.
 ---
 

--- a/content/services/courses/cpsc-349.md
+++ b/content/services/courses/cpsc-349.md
@@ -1,5 +1,6 @@
 ---
 title: Honours Research Seminar
 layout: course
+description: Students will attend a series of research seminars presented by faculty members, produce a thesis proposal, and choose their honours thesis supervisor. Available to Honours students. Majors students with satisfactory standing may also be permitted to enrol.
 ---
 

--- a/content/services/courses/cpsc-368.md
+++ b/content/services/courses/cpsc-368.md
@@ -1,5 +1,6 @@
 ---
 title: Databases in Data Science
 layout: course
+description: Overview of relational and non-relational database systems, role and usage of a database when querying data, data modelling, query languages, and query optimization.
 ---
 

--- a/content/services/courses/cpsc-402.md
+++ b/content/services/courses/cpsc-402.md
@@ -1,0 +1,5 @@
+---
+title: Numerical Linear Algebra
+layout: course
+description: Investigation of the practical techniques of computational linear algebra. Orthogonal transformations and their application to the solution of linear equations, the eigenproblem, and linear least squares. Complete solution of the symmetric eigenproblem, including bisection and the QR method. Refinements of these techniques for sparse matrices.
+---

--- a/content/services/courses/cpsc-404.md
+++ b/content/services/courses/cpsc-404.md
@@ -1,4 +1,5 @@
 ---
 title: Advanced Relational Databases
 layout: course
+description: Physical database design, indexing, relational query processing and optimization, transaction processing, concurrency control, crash recovery, data warehouses, data cubes, views, special topics.
 ---

--- a/content/services/courses/cpsc-406.md
+++ b/content/services/courses/cpsc-406.md
@@ -1,5 +1,6 @@
 ---
 title: Computational Optimization
 layout: course
+description: Formulation and analysis of algorithms for continuous and discrete optimization problems; linear, nonlinear, network, dynamic, and integer optimization; large-scale problems; software packages and their implementation; duality theory and sensitivity.
 ---
 

--- a/content/services/courses/cpsc-410.md
+++ b/content/services/courses/cpsc-410.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Software Engineering
 layout: course
+description: Specification, design, construction and validation of multi-version software systems.
 ---
 

--- a/content/services/courses/cpsc-411.md
+++ b/content/services/courses/cpsc-411.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Compiler Construction
 layout: course
+description: A practical introduction to lexical analysis, syntactic analysis, type-checking, code generation and optimization. This will be used to design and implement a compiler for a small language.
 ---
 

--- a/content/services/courses/cpsc-415.md
+++ b/content/services/courses/cpsc-415.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Operating Systems
 layout: course
+description: Process synchronization and communication schemes, including message-passing and concepts of monitor and serializer. Virtual memory systems management and the problem of information sharing in such systems. The working set principle. Traps and interrupt handling. Elementary queuing theory and its application such as process scheduling, system balancing and load control. File systems and operating system design methodologies.
 ---
 

--- a/content/services/courses/cpsc-416.md
+++ b/content/services/courses/cpsc-416.md
@@ -1,5 +1,6 @@
 ---
 title: Distributed Systems
 layout: course
+description: Concepts and design of distributed systems. Communication architecture and models for interprocess communication. Process migration, naming, distributed file systems, fault tolerance, and concurrency control.
 ---
 

--- a/content/services/courses/cpsc-417.md
+++ b/content/services/courses/cpsc-417.md
@@ -1,5 +1,6 @@
 ---
 title: Computer Networking
 layout: course
+description: Network protocols and architecture including internetworking, the Internet, layered communication protocols, routing, flow and congestion control, network performance, wired and wireless data communication.
 ---
 

--- a/content/services/courses/cpsc-418.md
+++ b/content/services/courses/cpsc-418.md
@@ -1,0 +1,6 @@
+---
+title: Parallel Computation
+layout: course
+description: Algorithms, architectures, and programming paradigms for parallel computation. Shared memory, message passing, and data parallel architectures and programming models. Parallel algorithms including reduce, scan, and sorting networks. Reasoning about the correctness of parallel programs. Performance analysis and measurement for parallel programs.
+---
+

--- a/content/services/courses/cpsc-420.md
+++ b/content/services/courses/cpsc-420.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Algorithms Design and Analysis
 layout: course
+description: The study of advanced topics in the design and analysis of algorithms and associated data structures. Topics include algorithms for graph-theoretic; algebraic and geometric problems; algorithms on nonsequential models; complexity issues; approximation algorithms.
 ---
 

--- a/content/services/courses/cpsc-421.md
+++ b/content/services/courses/cpsc-421.md
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Theory of Computing
 layout: course
+description: Characterizations of computability (using machines, languages and functions). Universality, equivalence and Church's thesis. Unsolvable problems. Restricted models of computation. Finite automata, grammars and formal languages.
 ---
 

--- a/content/services/courses/cpsc-422.md
+++ b/content/services/courses/cpsc-422.md
@@ -1,5 +1,6 @@
 ---
 title: Intelligent Systems
 layout: course
+description: Principles and techniques underlying the design, implementation and evaluation of intelligent computational systems. Applications of artificial intelligence to natural language understanding, image understanding and computer-based expert and advisor systems. Advanced symbolic programming methodology.
 ---
 

--- a/content/services/courses/cpsc-424.md
+++ b/content/services/courses/cpsc-424.md
@@ -1,0 +1,6 @@
+---
+title: Geometric Modelling
+layout: course
+description: Digital representation of curves and surfaces, including splines, subdivision surfaces and meshes. Principles, algorithms and mathematical foundations for geometry representation in computer graphics, computer vision, fabrication, CAD/CAM, and medical imaging. Algorithms for acquisition, creation, representation, and processing of 3D shapes.
+---
+

--- a/content/services/courses/cpsc-425.md
+++ b/content/services/courses/cpsc-425.md
@@ -1,5 +1,6 @@
 ---
 title: Computer Vision
 layout: course
+description: Introduction to the processing and interpretation of images. Image sensing, sampling, and filtering. Algorithms for colour analysis, texture description, stereo imaging, motion interpretation, 3D shape recovery, and recognition.
 ---
 

--- a/content/services/courses/cpsc-426.md
+++ b/content/services/courses/cpsc-426.md
@@ -1,5 +1,6 @@
 ---
 title: Computer Animation
 layout: course
+description: Motion in computer graphics for characters and their environments. Keyframing, inverse kinematics, particle systems, rigid body dynamics, contact and collision, controller-based active motion, motion capture.
 ---
 

--- a/content/services/courses/cpsc-427.md
+++ b/content/services/courses/cpsc-427.md
@@ -1,5 +1,0 @@
----
-title: Video Game Programming
-layout: course
----
-

--- a/content/services/courses/cpsc-430.md
+++ b/content/services/courses/cpsc-430.md
@@ -1,5 +1,7 @@
 ---
 title: Computers and Society
 layout: course
+description: >
+  Impact of computer technology on society; historical perspectives; social and economic consequences of large-scale information processing systems and automatic control; legal and ethical problems in computer applications. Computers and the individual: machine versus human capabilities, fact and fancy; problematic interface between man and machine.
 ---
 

--- a/content/services/courses/cpsc-436.md
+++ b/content/services/courses/cpsc-436.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Computer Science (All)
 layout: course
+description: Selected topics in a specific area within Computer Science. May be taken more than once for credit with permission of the department.
 ---
 

--- a/content/services/courses/cpsc-440.md
+++ b/content/services/courses/cpsc-440.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Machine Learning
 layout: course
+description: Advanced machine learning techniques focusing on probabilistic models. Deep learning and differentiable programming, exponential families and Bayesian inference, probabilistic graphical models and other generative models, Monte Carlo and variational inference methods.
 ---
 

--- a/content/services/courses/cpsc-444.md
+++ b/content/services/courses/cpsc-444.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Methods for Human Computer Interaction
 layout: course
+description: Design and evaluation methodologies and theories; formal models of the user including visual, motor, and information processing; advanced evaluation methods including laboratory experiments and field studies; HCI research frontiers.
 ---
 

--- a/content/services/courses/cpsc-445.md
+++ b/content/services/courses/cpsc-445.md
@@ -1,5 +1,6 @@
 ---
 title: Algorithms in Bioinformatics
 layout: course
+description: Sequence alignment, phylogenetic tree reconstruction, prediction of RNA and protein structure, gene finding and sequence annotation, gene expression, and biomolecular computing.
 ---
 

--- a/content/services/courses/cpsc-448.md
+++ b/content/services/courses/cpsc-448.md
@@ -1,5 +1,6 @@
 ---
 title: Directed Studies in Computer Science (All)
 layout: course
+description: Open ordinarily to students in Computer Science with at least a 72% average and permission of the department. The course may consist of supervised reading, participation in a seminar, and one or more programming projects.
 ---
 

--- a/content/services/courses/cpsc-449.md
+++ b/content/services/courses/cpsc-449.md
@@ -1,5 +1,6 @@
 ---
 title: Honours Thesis
 layout: course
+description: Under supervision of a faculty member, students investigate a research topic and prepare a thesis.
 ---
 

--- a/content/services/courses/cpsc-491.md
+++ b/content/services/courses/cpsc-491.md
@@ -1,5 +1,6 @@
 ---
 title: Interactive Digital Media Practicum
 layout: course
+description: Design and implementation of interactive digital media systems using modern processes and tools. Projects provided by external clients or vetted entrepreneurial pitches are developed by interdisciplinary teams composed of one CPSC 491 student and multiple Master of Digital Media students.
 ---
 

--- a/content/services/courses/cpsc-501.md
+++ b/content/services/courses/cpsc-501.md
@@ -1,5 +1,0 @@
----
-title: Theory of Automata, Formal Languages and Computability
-layout: course
----
-

--- a/content/services/courses/cpsc-503.md
+++ b/content/services/courses/cpsc-503.md
@@ -1,5 +1,0 @@
----
-title: Computational Linguistics I
-layout: course
----
-

--- a/content/services/courses/cpsc-504.md
+++ b/content/services/courses/cpsc-504.md
@@ -1,6 +1,5 @@
 ---
-title: Topics in Data Management
+title: Data Management
 layout: course
 description: 
 ---
-

--- a/content/services/courses/cpsc-507.md
+++ b/content/services/courses/cpsc-507.md
@@ -1,6 +1,5 @@
 ---
-title: Topics in Data Management
+title: Software Engineering
 layout: course
 description: 
 ---
-

--- a/content/services/courses/cpsc-508.md
+++ b/content/services/courses/cpsc-508.md
@@ -1,6 +1,5 @@
 ---
-title: Topics in Data Management
+title: Operating Systems
 layout: course
 description: 
 ---
-

--- a/content/services/courses/cpsc-509.md
+++ b/content/services/courses/cpsc-509.md
@@ -1,5 +1,6 @@
 ---
 title: Programming Language Principles
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-513.md
+++ b/content/services/courses/cpsc-513.md
@@ -1,5 +1,0 @@
----
-title: Introduction to Formal Verification and Analysis
-layout: course
----
-

--- a/content/services/courses/cpsc-516.md
+++ b/content/services/courses/cpsc-516.md
@@ -1,6 +1,5 @@
 ---
-title: Topics in Data Management
+title: Computational Geometry
 layout: course
 description: 
 ---
-

--- a/content/services/courses/cpsc-521.md
+++ b/content/services/courses/cpsc-521.md
@@ -1,0 +1,5 @@
+---
+title: Parallel Algorithms and Architectures
+layout: course
+description: 
+---

--- a/content/services/courses/cpsc-524.md
+++ b/content/services/courses/cpsc-524.md
@@ -1,5 +1,0 @@
----
-title: Computer Graphics - Modelling
-layout: course
----
-

--- a/content/services/courses/cpsc-530.md
+++ b/content/services/courses/cpsc-530.md
@@ -1,5 +1,0 @@
----
-title: Topics in Information Processing
-layout: course
----
-

--- a/content/services/courses/cpsc-532.md
+++ b/content/services/courses/cpsc-532.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Artificial Intelligence (All)
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-533.md
+++ b/content/services/courses/cpsc-533.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Computer Graphics (All)
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-536.md
+++ b/content/services/courses/cpsc-536.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Algorithms and Complexity (All)
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-538.md
+++ b/content/services/courses/cpsc-538.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Computer Systems (All)
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-539.md
+++ b/content/services/courses/cpsc-539.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Programming Languages
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-540.md
+++ b/content/services/courses/cpsc-540.md
@@ -1,5 +1,6 @@
 ---
 title: Machine Learning
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-543.md
+++ b/content/services/courses/cpsc-543.md
@@ -1,5 +1,6 @@
 ---
 title: Physical User Interface Design and Evaluation
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-544.md
+++ b/content/services/courses/cpsc-544.md
@@ -1,5 +1,6 @@
 ---
 title: Human Computer Interaction
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-545.md
+++ b/content/services/courses/cpsc-545.md
@@ -1,4 +1,5 @@
 ---
 title: Algorithms for Bioinformatics
 layout: course
+description: 
 ---

--- a/content/services/courses/cpsc-547.md
+++ b/content/services/courses/cpsc-547.md
@@ -1,5 +1,6 @@
 ---
 title: Information Visualization
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-549.md
+++ b/content/services/courses/cpsc-549.md
@@ -1,5 +1,6 @@
 ---
 title: Master's Thesis (All)
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-554.md
+++ b/content/services/courses/cpsc-554.md
@@ -1,5 +1,6 @@
 ---
 title: Topics in Human-Computer Interaction
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-589.md
+++ b/content/services/courses/cpsc-589.md
@@ -1,5 +1,6 @@
 ---
 title: M.Sc. Major Essay
 layout: course
+description: 
 ---
 

--- a/content/services/courses/cpsc-649.md
+++ b/content/services/courses/cpsc-649.md
@@ -1,5 +1,6 @@
 ---
 title: Doctoral Dissertation
 layout: course
+description: 
 ---
 

--- a/themes/hugo-bootstrap-5/layouts/services/course.html
+++ b/themes/hugo-bootstrap-5/layouts/services/course.html
@@ -16,6 +16,10 @@
   <h3 class="blog-post-title mb-0">{{ .Title | markdownify }}</h3>
 </header>
 <article class="blog-post">
+  {{ with .Description }}
+    <hr />
+    {{ . }}
+  {{ end }}
   {{ with (index $.Site.Data.courseReviews .File.ContentBaseName)}}
     {{$averageDifficulty := 0 }}
     {{ $difficultyCount := 0 }}


### PR DESCRIPTION
This PR adds the course description from the SSC (if one exists) to the top of each course page. Also deletes some old empty courses that aren't offered anymore.
Closes #248.
