### PR TITLE
Fix setInterval → setTimeout

### DIFF
--- a/assets/js/newsletter.js
+++ b/assets/js/newsletter.js
@@ -1,6 +1,6 @@
 (() => {
     // add 10 second delay in showing the newsletter popup
-    setInterval(() => {
+    setTimeout(() => {
         const newsletterModalEl = document.getElementById('newsletter-modal');
         const newsletterModal = new bootstrap.Modal(newsletterModalEl);
         if (document.cookie.indexOf('newsletter') < 0) {


### PR DESCRIPTION
Currently, the newsletter signup modal will continue to spawn the darkened background at an interval of 10 seconds. If a user navigates to our page for the first time, navigates off the page for a couple minutes, then comes back and clicks on one of the buttons, the backgrounds won't disappear, so they'll see a completely dark page.

Should be fixed with `setTimeout`, which runs only once. 