### PR TITLE
Add shortcode for clubs unified calendar

### DIFF
--- a/content/about/clubs.md
+++ b/content/about/clubs.md
@@ -52,3 +52,9 @@ The following UBC CS-related clubs are partners of the CSSS.
 
 ## Engineering Design Teams
 Many engineering design teams accept computer science students, and need software engineers. A list of all engineering design teams can be found <a href="https://teams.engineering.ubc.ca/the-teams/">here</a>.
+
+## Club Events Calendar
+
+This calendar shows a selection of events from CSSS partner clubs and the CS department. If you're a club executive and would like your event added to this calendar, please contact us through the [suggestions box](https://ubccsss.org/contact/suggestions-box/).
+
+{{< club-calendar "https://ubccsss.org/events/index.ics" >}}

--- a/themes/hugo-bootstrap-5/layouts/shortcodes/club-calendar.html
+++ b/themes/hugo-bootstrap-5/layouts/shortcodes/club-calendar.html
@@ -1,0 +1,14 @@
+<iframe
+  id="open-web-calendar"
+  style="
+    background: url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif')
+      center center no-repeat;
+  "
+  src="https://open-web-calendar.herokuapp.com/calendar.html?{{ range .Params}}url={{ htmlEscape . }}&{{end}}title=CS%20Club%20Events%20Calendar"
+  sandbox="allow-scripts allow-same-origin allow-top-navigation"
+  allowTransparency="true"
+  scrolling="no"
+  frameborder="0"
+  height="600px"
+  width="100%"
+></iframe>


### PR DESCRIPTION
This PR is part of #255 - it adds an events calendar similar to the one on our homepage, but can include multiple event feeds. The shortcode takes in any number of hosted ICS files (calendar event format files that can be exposed through GCal), and displays them on the clubs page.  

Currently, only the CSSS events are shown, but other feeds can easily be added pending more outreach for club events! 

Let me know if an exec's email should be listed instead of redirecting to the suggestions box.