### PR TITLE
Add course session taken information

### DIFF
--- a/assets/js/create-github-issue.js
+++ b/assets/js/create-github-issue.js
@@ -6,6 +6,9 @@ const WORKER_URL = form.dataset.workerurl;
 
 // call createGithubIssue if form is valid and display link to the new issue
 (() => {
+  document.getElementById("github-issue-year-taken").max =
+    new Date().getFullYear();
+
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
     event.stopPropagation();

--- a/assets/js/create-github-issue.js
+++ b/assets/js/create-github-issue.js
@@ -50,6 +50,9 @@ const createGithubIssue = async () => {
   const review = document.getElementById("github-issue-review").value;
   const difficulty = document.getElementById("github-issue-difficulty").value;
   const quality = document.getElementById("github-issue-quality").value;
+  const sessionTaken =
+    document.getElementById("github-issue-year-taken").value +
+    document.getElementById("github-issue-session-taken").value;
 
   // check if reCAPTCHA has been completed
   const token = grecaptcha.getResponse();
@@ -75,6 +78,7 @@ const createGithubIssue = async () => {
           reference: reference,
           difficulty: difficulty,
           quality: quality,
+          sessionTaken: sessionTaken,
         },
       }),
     });

--- a/themes/hugo-bootstrap-5/layouts/partials/course/review.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/course/review.html
@@ -9,7 +9,8 @@
 <cite class="blockquote-footer"
   >{{with .authorLink }}<a href="{{ . }}"
     >{{end}}{{ .author }}{{with .authorLink}}</a
-  >{{end}}, {{ dateFormat "Jan 2 2006" .date }}
+  >{{end}}, {{ dateFormat "Jan 2 2006" .date }}{{with .sessionTaken}}, course
+  taken {{.}}{{end}}
 </cite>
 {{end}}
 <br />

--- a/themes/hugo-bootstrap-5/layouts/partials/github-issue-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-issue-form.html
@@ -29,13 +29,12 @@ $course := replace (upper .File.ContentBaseName) "-" " " }}
       <div class="invalid-feedback">Please enter a name/username.</div>
     </div>
     <div class="my-3">
-      <label for="github-issue-reference" class="form-label">Reference*</label>
+      <label for="github-issue-reference" class="form-label">Attribution</label>
       <input
         class="form-control"
         type="url"
         id="github-issue-reference"
-        placeholder="link to the review or a link to your GitHub if this is your review"
-        required
+        placeholder="link to a personal website or GitHub, leave empty if you wish to remain anonymous"
       />
       <div class="invalid-feedback">
         Enter a valid url including the 'https://' prefix.
@@ -55,6 +54,31 @@ $course := replace (upper .File.ContentBaseName) "-" " " }}
       ></textarea>
       <div class="invalid-feedback">
         Please enter your course review. <b>[minimum length: 50 characters]</b>
+      </div>
+    </div>
+    <div class="my-3">
+      <label for="github-issue-session-taken" class="form-label"
+        >Session Taken*</label
+      >
+      <div class="input-group">
+        <input
+          type="number"
+          class="form-control"
+          placeholder="enter year the course was taken"
+          min="1908"
+          id="github-issue-year-taken"
+        />
+        <select
+          class="form-select"
+          aria-label="Choose a session"
+          required
+          id="github-issue-session-taken"
+        >
+          <option value="W1" selected>W1 (Fall)</option>
+          <option value="W2">W2 (Spring)</option>
+          <option value="S1">S1 (Summer Term 1)</option>
+          <option value="S2">S2 (Summer Term 2)</option>
+        </select>
       </div>
     </div>
     <div class="my-3">
@@ -104,3 +128,8 @@ $course := replace (upper .File.ContentBaseName) "-" " " }}
     </div>
   </form>
 </div>
+
+<script>
+  document.getElementById("github-issue-year-taken").max =
+    new Date().getFullYear();
+</script>

--- a/themes/hugo-bootstrap-5/layouts/partials/github-issue-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-issue-form.html
@@ -128,8 +128,3 @@ $course := replace (upper .File.ContentBaseName) "-" " " }}
     </div>
   </form>
 </div>
-
-<script>
-  document.getElementById("github-issue-year-taken").max =
-    new Date().getFullYear();
-</script>


### PR DESCRIPTION
This PR:
- [renames the reference field to attribution, and makes the field optional](https://ubccsss.slack.com/archives/C03G2GP5UUX/p1665858390287769)
- [adds a semester taken input to the course review form](https://ubccsss.slack.com/archives/C03G2GP5UUX/p1665858431366749)
- adds the parameter to the GitHub issue creation script

No current reviews have this yet, but the session taken information would look like:
![image](https://user-images.githubusercontent.com/45278276/196058864-0ef15142-53e0-41a4-a55f-f0013036bad5.png)
 