### PR TITLE
Move exams + course reviews out of header

### DIFF
--- a/config/_default/menu.yml
+++ b/config/_default/menu.yml
@@ -15,14 +15,19 @@ main:
     name: Services
     url: /services/
     weight: -110
-  - identifier: databases
-    name: Databases
+  - identifier: exams
+    name: Past Exams 
+    url: /services/exams/
     weight: -100
+  - identifier: courses
+    name: Course Reviews 
+    url: /services/courses/
+    weight: -90
   - identifier: clubs
     name: Clubs
     url: /about/clubs/
-    weight: -90
+    weight: -80
   - identifier: contact
     name: Contact
     url: /contact/
-    weight: -80
+    weight: -70

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,17 +14,6 @@
         <ul class="navbar-nav">
           {{ $url := .RelPermalink | relLangURL }}
           {{ range .Site.Menus.main }}
-            {{ if eq .Name "Databases" }}
-              <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="databaseDropdownLink" role="button" data-bs-toggle="dropdown">
-                  Databases
-                </a>
-                <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="/services/exams">Exams</a></li>
-                  <li><a class="dropdown-item" href="/services/courses">Course Reviews</a></li>
-                </ul>
-              </li>
-            {{ else }}
               <li class="nav-item">
                 {{ if eq (hasPrefix .URL "mailto:") true }}
                   <a class="nav-link" href="{{ .URL }}">{{ .Name }}</a>
@@ -33,7 +22,6 @@
                   <a class="nav-link {{ if eq $url $menuUrl }}active{{end}}" href="{{ $menuUrl }}">{{ .Name }}</a>
                 {{ end }}
               </li>
-            {{ end }}
           {{ end }}
         </ul>
         {{ if gt (len .Site.Home.AllTranslations) 1 }}


### PR DESCRIPTION
This PR removes the databases dropdown in favour of having the exams + course reviews in the actual header [as per here](https://ubccsss.slack.com/archives/C03G2GP5UUX/p1666056465463029).