### PR TITLE
hotfix: spacing for circles

### DIFF
--- a/themes/hugo-bootstrap-5/layouts/partials/course/rating.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/course/rating.html
@@ -16,7 +16,7 @@
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-circle-fill {{ $color }}"
+    class="bi bi-circle-fill me-1 {{ $color }}"
     viewBox="0 0 16 16"
 >
     <circle cx="8" cy="8" r="8"/>
@@ -29,7 +29,7 @@
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-circle-half {{ $color }}"
+    class="bi bi-circle-half me-1 {{ $color }}"
     viewBox="0 0 16 16"
 >
     <path d="M8 15A7 7 0 1 0 8 1v14zm0 1A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"/>
@@ -42,7 +42,7 @@
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-circle {{ $color }}"
+    class="bi bi-circle me-1 {{ $color }}"
     viewBox="0 0 16 16"
 >
     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>

--- a/themes/hugo-bootstrap-5/layouts/partials/course/review.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/course/review.html
@@ -6,14 +6,14 @@
     {{if not (eq .difficulty 0)}}
     <tr>
         <td class="pe-2">Difficulty:</td>
-        <td class="pe-2">{{ partial "course/rating" (dict "rating" .difficulty "color" "text-secondary") }}</td>
+        <td class="pe-1">{{ partial "course/rating" (dict "rating" .difficulty "color" "text-secondary") }}</td>
         <td>{{ .difficulty }}</td>
     </tr>
     {{end}}
     {{if not (eq .quality 0)}}
     <tr>
         <td class="pe-2">Quality:</td>
-        <td class="pe-2">{{ partial "course/rating" (dict "rating" .quality) }}</td>
+        <td class="pe-1">{{ partial "course/rating" (dict "rating" .quality) }}</td>
         <td>{{ .quality }}</td>
     </tr>
     {{end}}


### PR DESCRIPTION
For some reason, the website is missing spacing despite it being present on the preview and localhost. I think something like this happened before with something else. This should fix it, I think.

This fix adds spacing in-between svgs below:

<img width="496" alt="Screenshot 2022-12-04 at 8 32 35 AM" src="https://user-images.githubusercontent.com/39626451/205503233-d4c32a27-48dc-43e0-900f-607a9d786cb0.png">
