### PR TITLE
Removed non-existent `tabs` option and updated actions/checkout to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.prettierrc
+++ b/.prettierrc
@@ -16,7 +16,6 @@
       ],
       "options": {
         "trailingComma": "none",
-        "tabs": true,
         "tabWidth": 2,
         "printWidth": 120
       }


### PR DESCRIPTION
The correct option is `useTabs` and we are using the default value.