### PR TITLE
Delete ubccsss.org.iml

### DIFF
--- a/ubccsss.org.iml
+++ b/ubccsss.org.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
This is an IntelliJ module file used for keeping module configuration. Pretty sure that we can delete it, it shouldn't be committed.