### PR TITLE
Run Prettier on push to main instead of per-PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
@@ -12,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
@@ -21,4 +26,3 @@ jobs:
           prettier_options: --write **/*.+(js|html|css|json|md|yaml|yml)
           only_changed: True
           prettier_plugins: prettier-plugin-go-template
-          commit_message: "Prettified code"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Prettifier
 
 on:
-  pull_request:
-    branches: [master]
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR addresses #356.

Our previous workflow ran on PR updates to format code and push formatted commits to the PR branch. This had two issues (that we couldn't notice until it was deployed, and were low severity, so no worries!):
- The action couldn't pull branches on forks (can be fixed with `repository: ${{ github.event.pull_request.head.repo.full_name }}`, but see next point)
- The action doesn't have permission to push updates to PR branches unless the PR author expressly authorizes the action to collaborate on their forked repo

This new GitHub workflow formats files only after commits have been made to `main`. It would have been cleaner to do this in the PR, but it seems like with our current workflow the easiest path forward is to run it on push to main instead.

An alternative workflow would be to have everyone work on branches within this repository, in which case we can go back to running changes per-PR. This wouldn't allow other contributors outside the CSSS to have their PRs formatted though.