### PR TITLE
Fix TCF page companies display

### DIFF
--- a/themes/hugo-bootstrap-5/layouts/tcf/tcf-day-of.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf/tcf-day-of.html
@@ -83,7 +83,11 @@
           <p><a href="/files/tcf2023/menu.pdf">Food/Beverages at TCF</a></p>
         </li>
         <li>
-          <p><a href="/files/tcf2023/wifi-tutorial.pdf">UBC Visitor Internet Access at TCF</a></p>
+          <p>
+            <a href="/files/tcf2023/wifi-tutorial.pdf"
+              >UBC Visitor Internet Access at TCF</a
+            >
+          </p>
         </li>
       </ul>
     </div>

--- a/themes/hugo-bootstrap-5/layouts/tcf/tcf-main.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf/tcf-main.html
@@ -133,7 +133,7 @@
           {{ len (where .Pages ".Params.type" "tcf") }} Companies Attending
         </h1>
         <div class="row pt-4">
-          {{ range first 13 (sort .Pages) }}
+          {{ range first 12 (sort (where .Pages ".Params.type" "tcf")) }}
             {{ if .Params.imageLink }}
               <div class="col-lg-3 col-sm-12 col-md-6 mt-3">
                 <div class="card w-100 mt-3 h-100">


### PR DESCRIPTION
This PR fixes the issue of the TCF company preview grid not fully filling:

![image](https://user-images.githubusercontent.com/45278276/213330556-60dd8751-082f-4c19-94ed-b31fb5eab01a.png)

This was due to iterating through all pages in `content/tcf/` instead of all TCF company pages in `content/tcf`.