### PR TITLE
Fix 2021 Officers List

### DIFF
--- a/content/about/team/officers/2021.md
+++ b/content/about/team/officers/2021.md
@@ -7,17 +7,23 @@ aliases:
 
 ### Jeremy Qiao
 
-External Officer
+External Affairs Officer
 
 ---
 
-### Taryn Wou
+### Xiaoyang Zhang
 
 Communications Officer
 
 ---
 
 ### Ashmit Gupta
+
+Communications Officer
+
+---
+
+### Kit Liu 
 
 Communications Officer
 


### PR DESCRIPTION
This PR fixes the 2021-2022 communications officers list [as per Slack](https://ubccsss.slack.com/archives/C03G2GP5UUX/p1675395100381619?thread_ts=1675361578.994939&cid=C03G2GP5UUX).