### PR TITLE
Add TCF page pathname guard

### DIFF
--- a/content/events/2023-01-19-technical-career-fair.md
+++ b/content/events/2023-01-19-technical-career-fair.md
@@ -18,6 +18,10 @@ end_date: 2023-01-19 16:00:00
 
 ![](/files/Technical-Career-Fair-2023.png)
 
+[Click here to be redirected to our TCF 2023 site.](/tcf2023)
+
 <script>
-window.location.href = "https://ubccsss.org/tcf";
+if (window.location.pathname.includes("/events/2023/01/19/technical-career-fair/")) {
+	window.location.href = "https://ubccsss.org/tcf";
+}
 </script>


### PR DESCRIPTION
This PR closes #383.

The `/events` page loads the HTML of each event, and in the TCF HTML I'd added a simple `window.location.href` redirect to the TCF site.

I've added a guard now so it'll only redirect when you go to the event page, and added a link for people to click if they find the TCF post via the `/events` page.