### PR TITLE
Add raffle to course reviews page

### DIFF
--- a/assets/js/create-github-pr.js
+++ b/assets/js/create-github-pr.js
@@ -57,6 +57,7 @@ const createGithubPR = async () => {
   const quality = document.getElementById("github-pr-quality").value;
   const sessionTaken =
     document.getElementById("github-pr-year-taken").value + document.getElementById("github-pr-session-taken").value;
+  const email = document.getElementById("github-pr-raffle-email").value;
 
   // check if reCAPTCHA has been completed
   const token = grecaptcha.getResponse();
@@ -82,7 +83,8 @@ const createGithubPR = async () => {
           reference: reference,
           difficulty: difficulty,
           quality: quality,
-          sessionTaken: sessionTaken
+          sessionTaken: sessionTaken,
+          email: email,
         }
       })
     });

--- a/assets/js/create-github-pr.js
+++ b/assets/js/create-github-pr.js
@@ -84,7 +84,7 @@ const createGithubPR = async () => {
           difficulty: difficulty,
           quality: quality,
           sessionTaken: sessionTaken,
-          email: email,
+          email: email
         }
       })
     });

--- a/content/about/team/officers/2021.md
+++ b/content/about/team/officers/2021.md
@@ -23,7 +23,7 @@ Communications Officer
 
 ---
 
-### Kit Liu 
+### Kit Liu
 
 Communications Officer
 

--- a/content/events/2023-02-06-computer-science-hoodies.md
+++ b/content/events/2023-02-06-computer-science-hoodies.md
@@ -21,3 +21,4 @@ end_date: 2023-02-13 12:00:00
 
 Stay cozy and stylish with Computer Science hoodies! Show off your love for UBC Computer Science with these high-quality hoodies, now available at a discounted price of $40! Hurry and grab yours before the offer ends on 13th February (or while stocks last) at the Cube (ICCS 021). Don't miss out on this limited time offer!
 
+Check out our [course reviews](https://ubccsss.org/services/courses/) page too! Each course review is an entry to win 50% off a CSSS hoodie ($22.50 value) or one of five $10 AMS gift cards! Maximum five entries per person. Raffle will take place at the end of the 2022W2 term.

--- a/content/events/2023-02-14-valentines-day-bubble-tea-event.md
+++ b/content/events/2023-02-14-valentines-day-bubble-tea-event.md
@@ -4,9 +4,9 @@ title: "Valentine's Day Bubble Tea Event"
 # Publishing date when the event appears, not the date of the event.
 date: 2023-02-07
 # Tags that apply to the event
-tags: ["social","event"]
+tags: ["social", "event"]
 # Name of the author (you)
-author: Emilie Ma 
+author: Emilie Ma
 # Images associated to this event. Used for banner.
 images:
   - /files/valentines-day-bbt-event.png
@@ -21,9 +21,9 @@ end_date: 2023-02-14 14:30:00
 Want something sweet for Valentine’s Day? Come to the Cube on February 14th at 1:30 PM to try out bubble tea for just $2!
 
 Drinks available:
+
 - Pearl Milk Tea x50
 - Grass Jelly Roasted Milk Tea x25
 - Mango QQ x25
 
 Supplies are EXTREMELY limited so come early! Drink purchases are limited to one cup per person.
-

--- a/content/services/courses/_index.md
+++ b/content/services/courses/_index.md
@@ -5,6 +5,13 @@ cascade:
 layout: courses
 ---
 
+<div class="card mb-3">
+  <div class="card-body">
+  <span class="badge bg-primary me-1">New!</span>
+   Want to win fun prizes and share your thoughts on CPSC courses? Each course review is an entry to win 50% off a CSSS hoodie ($22.50 value) or one of five $10 AMS gift cards! Maximum five entries per person. Raffle will take place at the end of the 2022W2 term.
+  </div>
+</div>
+
 Here you can find a collection of course reviews and descriptions from UBC students and TAs, sorted by year. Some have been sourced from Reddit and student websites. Students who are interested in contributing may edit the page with the "Edit on Github" link or fill the form to create a Github issue that will be reviewed by an officer.
 
 _NOTE_: These reviews and descriptions are here as reference ONLY. Course content vary from year to year, so any materials on this website might be out of date. We are not responsible for any mistakes in the reviews and descriptions provided herein; however, we will accept notifications as such so we can place appropriate notices.

--- a/data/courseReviews/cpsc-304.yaml
+++ b/data/courseReviews/cpsc-304.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: annonn
-    authorLink: 
+    authorLink:
     date: 2023-02-03
     review: |
       Teaches all the basic you need to get started with Relational Databases. Highly recommend taking this course even though it is not a required course for the CPSC major. The project was easy and almost everyone got a 100% in it. Course final and assignments were also easy. Not too heavy course load.

--- a/data/courseReviews/cpsc-310.yaml
+++ b/data/courseReviews/cpsc-310.yaml
@@ -10,7 +10,7 @@ reviews:
     quality: 2
     sessionTaken: 2022W1
   - author: anonymous
-    authorLink: 
+    authorLink:
     date: 2023-02-03
     review: |
       Very length and time consuming project. Teaches you a great deal about software construction and various design concepts for building maintainable systems. Make sure to start working on the project deadlines early!

--- a/data/courseReviews/cpsc-310.yaml
+++ b/data/courseReviews/cpsc-310.yaml
@@ -1,11 +1,11 @@
 reviews:
   - author: Andy Liang
-    authorLink: 
+    authorLink:
     date: 2023-02-05
     review: |
       The course consists of a full stack project (no DB) where the hardest part of the project is actually more algorithm related ish (building a query engine) than it is software construction in my opinion. The project itself ended up being very useless (especially if you have done one decent full stack personal project or have coop experience) since there is no code quality enforcement. This means you are free to write garbage code, as long as it works. I would advice to start early on the project though!
-      
-      The conceptual portion taught in lecture is useful. However the project, nor any other part of the course, really forces you to try the design patterns that you have learned. :) 
+
+      The conceptual portion taught in lecture is useful. However the project, nor any other part of the course, really forces you to try the design patterns that you have learned. :)
     difficulty: 3
     quality: 2
     sessionTaken: 2022W1

--- a/data/courseReviews/cpsc-312.yaml
+++ b/data/courseReviews/cpsc-312.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: /u/xKaillus
-    authorLink: 
+    authorLink:
     date: 2023-01-31
     review: |
       i loved 312!! Steve Wolfman taught it in my offering last term (2021W1) and it was really fun - he really made the course worth it with his teaching style and enthusiasm and we learned all about really interesting programming languages that are outside the traditional few (C, C++, Java, JavaScript) as well as some programming tasks that are much easier/faster in those different paradigm languages! probably one of the most insightful and enjoyable classes I've taken in my degree so far next to 340

--- a/data/courseReviews/cpsc-317.yaml
+++ b/data/courseReviews/cpsc-317.yaml
@@ -1,9 +1,9 @@
 reviews:
   - author: cpscstuednt
-    authorLink: 
+    authorLink:
     date: 2023-02-03
     review: |
-      Great course, even though it is not required for a major, I would highly recommend it. Very in demand skills and applicable content. 
+      Great course, even though it is not required for a major, I would highly recommend it. Very in demand skills and applicable content.
     difficulty: 3.5
     quality: 5
     sessionTaken: 2023W2

--- a/data/courseReviews/cpsc-320.yaml
+++ b/data/courseReviews/cpsc-320.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: anon
-    authorLink: 
+    authorLink:
     date: 2023-02-03
     review: |
       Very useful code to get you a job in the industry. Helps you in almost all Data Structure and Algorithm questions.

--- a/data/courseReviews/cpsc-404.yaml
+++ b/data/courseReviews/cpsc-404.yaml
@@ -1,9 +1,9 @@
 reviews:
   - author: HK
-    authorLink: 
+    authorLink:
     date: 2023-02-06
     review: |
-      Course is taught well but the material becomes complicated pretty quickly. Took it w Ed Knorr and he had a student-friendly grading policy (3 midterms with worst one being replaced by your final if the latter is better). Each midterm was a month apart and no major assignments that take over your weekends. You could get 13% right-away on the course via clickers, In-Class/Pre-class exercises that are graded based partially on effort and correctness. 
+      Course is taught well but the material becomes complicated pretty quickly. Took it w Ed Knorr and he had a student-friendly grading policy (3 midterms with worst one being replaced by your final if the latter is better). Each midterm was a month apart and no major assignments that take over your weekends. You could get 13% right-away on the course via clickers, In-Class/Pre-class exercises that are graded based partially on effort and correctness.
     difficulty: 4.5
     quality: 5
     sessionTaken: 2022W1

--- a/data/tutor.yaml
+++ b/data/tutor.yaml
@@ -107,7 +107,7 @@
 
 - name: Daocheng Wang
   lastmod: 2023-02-04
-  courses: ["CPSC110", "CPSC121","CPSC210"]
+  courses: ["CPSC110", "CPSC121", "CPSC210"]
   email: wangdc2010@gmail.com
   rates: $60-70/hr
   bio: Tech Lead @ one of FAANG companies.
@@ -210,16 +210,7 @@
 - name: Jacob Hotz
   lastmod: 2022-09-17
   courses:
-    [
-      CPSC110,
-      CPSC121,
-      CPSC210,
-      CPSC213,
-      CPSC213,
-      CPSC103,
-      CPSC107,
-      CPSC313
-    ]
+    [CPSC110, CPSC121, CPSC210, CPSC213, CPSC213, CPSC103, CPSC107, CPSC313]
   email: hotzjacobb@yahoo.com
   bio: |
     Experienced TA (have previously TA'd both 110 and 121) in my final year of UBC CS with a passion for teaching and learning.
@@ -278,7 +269,7 @@
 
 - name: Jay Ho
   lastmod: 2023-02-04
-  courses: ["CPSC210","CPSC304","CPSC310"]
+  courses: ["CPSC210", "CPSC304", "CPSC310"]
   email: jayhomn@gmail.com
   bio: |
     I am a fourth year computer science student with 4 terms of TA experience for CPSC 210 and CPSC 213. In addition, I have achieved these grades for the three respective courses I'm tutoring for:
@@ -302,7 +293,18 @@
 
 - name: Lewis Nicolle
   lastmod: 2023-02-04
-  courses: [CPSC210, CPSC213, CPSC221, CPSC310, CPSC313, CPSC314, CPSC317, CPSC320, CPSC418]
+  courses:
+    [
+      CPSC210,
+      CPSC213,
+      CPSC221,
+      CPSC310,
+      CPSC313,
+      CPSC314,
+      CPSC317,
+      CPSC320,
+      CPSC418
+    ]
   email: musicaljelly@gmail.com
   bio: |
     Graduated from UBC with a Bachelor's in CS in 2017. Have worked in the game industry for 5+ years, at companies like Capcom, EA, and Relic Entertainment. I specialize in graphics/rendering (D3D11/12, HLSL, PBR), and in low-level systems programming (C/C++/assembly, optimization, Windows API). Beyond coursework, I can also tutor in game and game engine programming, and help with interview prep for game companies.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,11 +29,11 @@
                 <a class="nav-link" href="{{ .URL }}">{{ .Name }}</a>
               {{ else }}
                 {{ $menuUrl := .URL | relLangURL }}
-                  <a
-                    class="nav-link {{ if eq $url $menuUrl }}active{{ end }}"
-                    href="{{ $menuUrl }}"
-                    >{{ .Name }}</a
-                  >
+                <a
+                  class="nav-link {{ if eq $url $menuUrl }}active{{ end }}"
+                  href="{{ $menuUrl }}"
+                  >{{ .Name }}</a
+                >
               {{ end }}
             </li>
           {{ end }}

--- a/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
@@ -120,9 +120,7 @@
       </label>
       <p>
         <small class="text-muted"
-          >Enter your UBC CWL email here for the chance to win a CSSS Hoodie
-          (TODO)! See the terms and more information on the raffle
-          <a href="#TODO">here</a>. This email will not be visible on the
+          >Enter your UBC CWL email here to enter in a raffle to win 50% off a CSSS Hoodie ($22.50 value) or one of five $10 AMS gift cards! Each course review is an entry in the raffle, with a maximum of five entries per person. Raffle will take place at the end of the 2022W2 term. This email will not be visible on the
           published review.</small
         >
       </p>

--- a/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
@@ -120,8 +120,11 @@
       </label>
       <p>
         <small class="text-muted"
-          >Enter your UBC CWL email here to enter in a raffle to win 50% off a CSSS Hoodie ($22.50 value) or one of five $10 AMS gift cards! Each course review is an entry in the raffle, with a maximum of five entries per person. Raffle will take place at the end of the 2022W2 term. This email will not be visible on the
-          published review.</small
+          >Enter your UBC CWL email here to enter in a raffle to win 50% off a
+          CSSS Hoodie ($22.50 value) or one of five $10 AMS gift cards! Each
+          course review is an entry in the raffle, with a maximum of five
+          entries per person. Raffle will take place at the end of the 2022W2
+          term. This email will not be visible on the published review.</small
         >
       </p>
       <div class="d-flex gap-2">

--- a/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
@@ -115,7 +115,7 @@
     </div>
     <div class="my-3">
       <label for="raffle-email" class="form-label">
-        Raffle Email
+        Raffle Email (Optional)
         <span class="badge bg-primary">New!</span>
       </label>
       <p>

--- a/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
@@ -113,6 +113,28 @@
         <small id="github-pr-quality-label" style="width: 3rem">3</small>
       </div>
     </div>
+<div class="my-3">
+      <label for="raffle-email" class="form-label">
+        Raffle Email 
+        <span class="badge bg-primary">New!</span>
+      </label>
+      <p>
+      <small class="text-muted">Enter your UBC CWL email here for the chance to win a CSSS Hoodie (TODO)! See the terms and more information on the raffle <a href="#TODO">here</a>. This email will not be visible on the published review.</small>
+      </p>
+      <div class="d-flex gap-2">
+      <input
+        class="form-control"
+        type="text"
+        pattern=".*@(student\.|alumni\.)?ubc\.ca"
+        id="github-pr-raffle-email"
+        placeholder="Enter your UBC CWL email"
+        style="width: fit-content;"
+        />
+      <div class="invalid-feedback">
+       Email must end in ubc.ca. 
+      </div>
+      </div>
+    </div>
     <div
       class="g-recaptcha my-3"
       data-sitekey="{{ .Site.Params.recaptchaSiteKey }}"></div>

--- a/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
@@ -113,26 +113,28 @@
         <small id="github-pr-quality-label" style="width: 3rem">3</small>
       </div>
     </div>
-<div class="my-3">
+    <div class="my-3">
       <label for="raffle-email" class="form-label">
-        Raffle Email 
+        Raffle Email
         <span class="badge bg-primary">New!</span>
       </label>
       <p>
-      <small class="text-muted">Enter your UBC CWL email here for the chance to win a CSSS Hoodie (TODO)! See the terms and more information on the raffle <a href="#TODO">here</a>. This email will not be visible on the published review.</small>
+        <small class="text-muted"
+          >Enter your UBC CWL email here for the chance to win a CSSS Hoodie
+          (TODO)! See the terms and more information on the raffle
+          <a href="#TODO">here</a>. This email will not be visible on the
+          published review.</small
+        >
       </p>
       <div class="d-flex gap-2">
-      <input
-        class="form-control"
-        type="text"
-        pattern=".*@(student\.|alumni\.)?ubc\.ca"
-        id="github-pr-raffle-email"
-        placeholder="Enter your UBC CWL email"
-        style="width: fit-content;"
-        />
-      <div class="invalid-feedback">
-       Email must end in ubc.ca. 
-      </div>
+        <input
+          class="form-control"
+          type="text"
+          pattern=".*@(student\.|alumni\.)?ubc\.ca"
+          id="github-pr-raffle-email"
+          placeholder="Enter your UBC CWL email"
+          style="width: fit-content;" />
+        <div class="invalid-feedback">Email must end in ubc.ca.</div>
       </div>
     </div>
     <div

--- a/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-main.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-main.html
@@ -130,7 +130,8 @@
     <div class="background-blue">
       <div class="container" id="companies">
         <h1 class="text-center mb-0">
-          {{ len (where .Pages ".Params.layout" "tcf-company") }} Companies Attending
+          {{ len (where .Pages ".Params.layout" "tcf-company") }} Companies
+          Attending
         </h1>
         <div class="row pt-4">
           {{ range first 12 (sort (where .Pages ".Params.layout" "tcf-company")) }}


### PR DESCRIPTION
This PR adds the email field for the hoodie / AMS gift card raffle on the course reviews page.

The main course reviews page now has a small card explaining the raffle, the course review form also has this information, and the hoodies post also has a small blurb added.