### PR TITLE
Fix Prettier workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Prettifier
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -20,10 +21,12 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.2
         with:
-          prettier_options: --write **/*.+(js|html|css|json|md|yaml|yml)
-          only_changed: True
+          prettier_options: --write "**/*.+(js|html|css|json|md|yaml|yml)"
           prettier_plugins: prettier-plugin-go-template
+          github_token: ${{ secrets.GH_TOKEN }}
+          only_changed: True

--- a/data/courseReviews/cpsc-310.yaml
+++ b/data/courseReviews/cpsc-310.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: Kristen F
-    authorLink: 
+    authorLink:
     date: 2023-02-15
     review: |
       Course was very much split into lecture content and project content. Lecture content was focused on Agile concepts and general industry terms and ideas, and was not difficult. Project had a quite intensive workload, but the end result of a full stack project is quite good on a resume. Personally found that the project coding was not extremely difficult, just time-consuming, and also required learning Promises.

--- a/data/courseReviews/cpsc-313.yaml
+++ b/data/courseReviews/cpsc-313.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: mar
-    authorLink: 
+    authorLink:
     date: 2023-02-13
     review: |
       well organized. has more work than some other cpsc classses (has quizzes, assignments, pre-lecture videos, inclass assignments...), but very manageable imo

--- a/data/courseReviews/cpsc-314.yaml
+++ b/data/courseReviews/cpsc-314.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: KF
-    authorLink: 
+    authorLink:
     date: 2023-02-15
     review: |
       Took this course with Dinesh Pai. If you've done matrix algebra, you'll be fine in terms of the math requirement for this course. Assignments were interesting but could be time-consuming in debugging. Good if you like JavaScript. Lectures focused on concepts behind computer graphics, shaders, etc, but did not help as much with the coding portion. Had to look online for learning a lot of Three.js. Almost half the midterm questions were the same as the ones in the quizzes / practice exams. Questions were also reused in final. Overall interesting course.

--- a/data/courseReviews/cpsc-320.yaml
+++ b/data/courseReviews/cpsc-320.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: Kristen F
-    authorLink: 
+    authorLink:
     date: 2023-02-15
     review: |
       Took this with Patrice Belleville. Extremely difficult course, but the course was ran well. Assignments were very tough, I needed to go to office hours and consult with peers very often for understanding of concepts. Prof was understanding and fair. Start assignments early and go to lectures & office hours, assignments can take up a significant portion of time to understand and office hours are often quite packed. Concepts taught in the course are very useful for industry and leetcode.

--- a/data/courseReviews/cpsc-404.yaml
+++ b/data/courseReviews/cpsc-404.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: KF
-    authorLink: 
+    authorLink:
     date: 2023-02-14
     review: |
       Course is well-taught and not too difficult, but quickly gains a lot of content and can be pretty dry at times. No programming or very little involved (some SQL). Took this class with Ed Knorr, his marking scheme is very helpful for students. There are pre-class and in-class exercises with frequent deadlines, but they're not difficult. Assignments had good instructions on what to follow.

--- a/data/courseReviews/cpsc-430.yaml
+++ b/data/courseReviews/cpsc-430.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: Kristen F
-    authorLink: 
+    authorLink:
     date: 2023-02-15
     review: |
       An ethics course focused on discussion about ethical problems within the tech sector. Took the course with Kevin Layton-Brown and Giulia Toti. Each week, there is a paragraph that you need to write (approximately 1500 characters (not words)), which will be peer-graded later. Depending on your previous amount of weekly work, you peer-grade 3 or more of your fellow peers' paragraphs (anonymously). No programming involved, but a lot of writing. Something to keep in mind if you find your writing skills are not as strong.

--- a/data/courseReviews/cpsc-436.yaml
+++ b/data/courseReviews/cpsc-436.yaml
@@ -1,6 +1,6 @@
 reviews:
   - author: yanyuz
-    authorLink: 
+    authorLink:
     date: 2023-02-13
     review: |
       CPSC436A OS DESIGN & IMPL


### PR DESCRIPTION
This PR fixes the Prettier workflow to correctly run on push to `master`.

Previously, the workflow couldn't run because its default authorization token didn't have permissions to bypass the branch protection filter currently set on `master`. This has been fixed by generating a personal access token for the `csssbot` account, granting it admin permissions for this repository, and passing in the token to the Prettier action.

I've also added a `workflow_dispatch` trigger so we can run the workflow manually if needed.