### PR TITLE
Fix course review date spacing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+themes/hugo-bootstrap-5/layouts/partials/course/review.html

--- a/themes/hugo-bootstrap-5/layouts/partials/course/review.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/course/review.html
@@ -28,8 +28,7 @@
     {{ else }}
       {{ .author }},
     {{ end }}
-    {{ dateFormat "Jan 2 2006" .date }}{{ with .sessionTaken }}
-      , course taken
+    {{ dateFormat "Jan 2 2006" .date }}{{ with .sessionTaken }}, course taken
       {{ . }}
     {{ end }}
   </cite>


### PR DESCRIPTION
This PR fixes the course review date spacing. Currently, it looks like this because Prettier autoformatted in newlines, adding indenting whitespace:
![image](https://user-images.githubusercontent.com/45278276/220511152-4c69c61a-90e4-4dc6-80aa-c773090b85af.png)

I've added a `.prettierignore` file to prevent it from being autoformatted again in the future (we can manually run Prettier locally and check for formatting issues first before committing). We should also be careful about autoformatting in PRs going forwards!