### PR TITLE
Add Leetcode Legends event updates

### DIFF
--- a/content/events/2023-03-06-csss-x-leetcode-legends-workshops.md
+++ b/content/events/2023-03-06-csss-x-leetcode-legends-workshops.md
@@ -15,10 +15,12 @@ images:
 start_date: 2023-03-07 18:00:00
 # End date and time (defaults to one hour after start). Used for calendar page.
 end_date: 2025-06-12 19:00:00
+file_ics: /static/files/leetcode-legends.ics
+when: "Every Tuesday and Thursday, 6-7PM"
 ---
 
 ![Leetcode Legends Poster](/files/2023-03-06-csssxleetcodelegends.png)
 
-Want to get better at technical interviews? Leetcode Legends is a group that will meet every Tuesday and Thursday for group practice sessions. This week (March 7 and 9), CSSS team members will be hosting an introductory session to Leetcode from 6-7 pm at ICICS 005 for students starting out with interview preparations. All skill levels are welcome!
+Want to get better at technical interviews? Leetcode Legends is a group that will meet every Tuesday and Thursday from 6-7 pm at ICICS 005 for students starting out with interview preparations. All skill levels are welcome!
 
-The event will run in a hybrid model. Current Zoom link [here](https://us05web.zoom.us/j/88342236357?pwd=cENVMG8zQUhlS1dwNWZsc2RlN3Bzdz09)!
+The event will also run in a hybrid model. Current Zoom link [here](https://us05web.zoom.us/j/88342236357?pwd=cENVMG8zQUhlS1dwNWZsc2RlN3Bzdz09)!

--- a/static/files/leetcode-legends.ics
+++ b/static/files/leetcode-legends.ics
@@ -1,0 +1,21 @@
+BEGIN:VEVENT
+DTSTAMP:20230316T155528Z
+UID:1g82mdcr4kmq5knn20m6dfi3vc-ll1@google.com
+DTSTART;TZID=America/Vancouver:20230309T180000
+RRULE:FREQ=WEEKLY;BYDAY=TH
+DTEND;TZID=America/Vancouver:20230309T190000
+SUMMARY:CSSS x Leetcode Legends Workshops [ICICS 005 + Zoom]
+DESCRIPTION:Want to get better at technical interviews? Leetcode Legends is a group that will meet every Tuesday and Thursday for group practice sessions. All skill levels are welcome!<br><br>The event will run in a hybrid model. The in-person location is ICICS 005. Current Zoom link :<a href="https://www.google.com/url?q=https://us05web.zoom.us/j/88342236357?pwd%3DcENVMG8zQUhlS1dwNWZsc2RlN3Bzdz09!&amp\;sa=D&amp\;source=calendar&amp\;usd=2&amp\;usg=AOvVaw3CtohIWPg8BtxlEIH5Va3N" target="_blank">https://us05web.zoom.us/j/88342236357?pwd=cENVMG8zQUhlS1dwNWZsc2RlN3Bzdz09!</a>
+LOCATION:ICICS Building\, 2366 Main Mall\, Vancouver\, BC V6T 1Z4\, Canada
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230316T155528Z
+UID:1d1olpovomekhqi46ujvbt9c0q-ll2@google.com
+DTSTART;TZID=America/Vancouver:20230307T180000
+RRULE:FREQ=WEEKLY;BYDAY=TU
+DTEND;TZID=America/Vancouver:20230307T190000
+SUMMARY:CSSS x Leetcode Legends Workshops [ICICS 005 + Zoom]
+DESCRIPTION:Want to get better at technical interviews? Leetcode Legends is a group that will meet every Tuesday and Thursday for group practice sessions. All skill levels are welcome!<br><br>The event will run in a hybrid model. The in-person location is ICICS 005. Current Zoom link :<a href="https://www.google.com/url?q=https://us05web.zoom.us/j/88342236357?pwd%3DcENVMG8zQUhlS1dwNWZsc2RlN3Bzdz09!&amp\;sa=D&amp\;source=calendar&amp\;usd=2&amp\;usg=AOvVaw3CtohIWPg8BtxlEIH5Va3N" target="_blank">https://us05web.zoom.us/j/88342236357?pwd=cENVMG8zQUhlS1dwNWZsc2RlN3Bzdz09!</a>
+LOCATION:ICICS Building\, 2366 Main Mall\, Vancouver\, BC V6T 1Z4\, Canada
+END:VEVENT
+

--- a/themes/hugo-bootstrap-5/layouts/events/list.ics
+++ b/themes/hugo-bootstrap-5/layouts/events/list.ics
@@ -4,6 +4,7 @@ PRODID:-//UBC CSSS//Event Calendar//EN
 CALSCALE:GREGORIAN
 METHOD:PUBLISH
 {{range .Pages -}}
+{{ if (not .Params.file_ics )}}
 {{- $startDate := .Params.start_date | default .Date }}
 {{- $endDate := .Params.end_date | default (time (add (time $startDate).Unix 36000)) }}
 BEGIN:VEVENT
@@ -16,5 +17,11 @@ DESCRIPTION:(Info: {{.Permalink}})
 {{ with (partial "event/address" .) }}LOCATION:{{ . }}{{ end }}
 URL:{{.Permalink}}
 END:VEVENT
+{{end }}
+{{end -}}
+{{range .Pages -}}
+{{if .Params.file_ics}}
+{{readFile .Params.file_ics}}
+{{end}}
 {{end -}}
 END:VCALENDAR

--- a/themes/hugo-bootstrap-5/layouts/events/single.html
+++ b/themes/hugo-bootstrap-5/layouts/events/single.html
@@ -19,7 +19,9 @@
       {{ partial "event/where" . }}
     </div>
 
-    {{ partial "event/add-to-calendar" . }}
+    {{ if not .Params.file_ics }}
+      {{ partial "event/add-to-calendar" . }}
+    {{ end }}
     <a class="btn btn-outline btn-primary my-3" href="./index.ics"
       >{{ i18n "addToIcsCalendar" }}</a
     >

--- a/themes/hugo-bootstrap-5/layouts/events/single.ics
+++ b/themes/hugo-bootstrap-5/layouts/events/single.ics
@@ -2,6 +2,7 @@ BEGIN:VCALENDAR
 CALSCALE:GREGORIAN
 METHOD:PUBLISH
 VERSION:2.0
+{{if not .Params.file_ics}}
 BEGIN:VEVENT
 {{- $startDate := .Params.start_date | default .Date }}
 {{- $endDate := .Params.end_date | default (time (add (time $startDate).Unix 36000)) }}
@@ -13,4 +14,7 @@ SUMMARY:{{.Title}}
 DESCRIPTION:(Info: {{.Permalink}})
 {{ with (partial "event/address" .) }}LOCATION:{{ . }}{{ end }}
 END:VEVENT
+{{else}}
+{{readFile .Params.file_ics}}
+{{end}}
 END:VCALENDAR

--- a/themes/hugo-bootstrap-5/layouts/partials/event/when.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/event/when.html
@@ -1,21 +1,26 @@
 {{ $startDate := .Params.start_date | default .Date }}
+{{ $whenDate := .Params.when | default "" }}
 {{ $endDate := .Params.end_date | default (add (time $startDate).Unix 36000) }}
 {{ $fullDate := "Mon January 2, 2006 - 15:04" }}
 {{ $isoDate := "2006-01-02" }}
 {{ $isoDateTime := "2006-01-02 15:04:05" }}
 <p class="my-0">
   <strong>When:</strong>
-  <time datetime="{{ dateFormat $isoDateTime $startDate }}"
-    >{{ dateFormat $fullDate $startDate }}</time
-  >
-  to
-  {{ if eq (dateFormat $isoDate $startDate) (dateFormat $isoDate $endDate) }}
-    <time datetime="{{ dateFormat $isoDateTime $endDate }}"
-      >{{ dateFormat "15:04" $endDate }}</time
+  {{ if eq $whenDate "" }}
+    <time datetime="{{ dateFormat $isoDateTime $startDate }}"
+      >{{ dateFormat $fullDate $startDate }}</time
     >
+    to
+    {{ if eq (dateFormat $isoDate $startDate) (dateFormat $isoDate $endDate) }}
+      <time datetime="{{ dateFormat $isoDateTime $endDate }}"
+        >{{ dateFormat "15:04" $endDate }}</time
+      >
+    {{ else }}
+      <time datetime="{{ dateFormat $isoDateTime $endDate }}"
+        >{{ dateFormat $fullDate $endDate }}</time
+      >
+    {{ end }}
   {{ else }}
-    <time datetime="{{ dateFormat $isoDateTime $endDate }}"
-      >{{ dateFormat $fullDate $endDate }}</time
-    >
+    {{ $whenDate }}
   {{ end }}
 </p>


### PR DESCRIPTION
This PR updates the Leetcode Legends workshop blurbs and adds the ability for custom ICS events to be specified and added to the calendar.

To add a custom ICS file (to take advantage of more complex recurrence behaviour), export an ICS file from Google Calendar or something similar, strip everything besides the `VEVENT` blocks, and add its file path, with `static`, in the `file_ics` field.

Also, the `when` field will now override the `When:` display at the bottom of each event.

This will not update in the deploy preview as we're linking to the hosted `ubccsss.org` ICS file, so please review locally.