### PR TITLE
Remove Course Reviews raffle copy

### DIFF
--- a/assets/js/create-github-pr.js
+++ b/assets/js/create-github-pr.js
@@ -57,7 +57,6 @@ const createGithubPR = async () => {
   const quality = document.getElementById("github-pr-quality").value;
   const sessionTaken =
     document.getElementById("github-pr-year-taken").value + document.getElementById("github-pr-session-taken").value;
-  const email = document.getElementById("github-pr-raffle-email").value;
 
   // check if reCAPTCHA has been completed
   const token = grecaptcha.getResponse();
@@ -83,8 +82,7 @@ const createGithubPR = async () => {
           reference: reference,
           difficulty: difficulty,
           quality: quality,
-          sessionTaken: sessionTaken,
-          email: email
+          sessionTaken: sessionTaken
         }
       })
     });

--- a/content/services/courses/_index.md
+++ b/content/services/courses/_index.md
@@ -9,13 +9,6 @@ location:
   name: Write a course review!
 ---
 
-<div class="card mb-3">
-  <div class="card-body">
-  <span class="badge bg-primary me-1">New!</span>
-   Want to win fun prizes and share your thoughts on CPSC courses? Each course review is an entry to win 50% off a CSSS hoodie ($22.50 value) or one of five $10 AMS gift cards! Maximum five entries per person. Raffle will take place at the end of the 2022W2 term.
-  </div>
-</div>
-
 Here you can find a collection of course reviews and descriptions from UBC students and TAs, sorted by year. Some have been sourced from Reddit and student websites. Students who are interested in contributing may edit the page with the "Edit on Github" link or fill the form to create a Github issue that will be reviewed by an officer.
 
 _NOTE_: These reviews and descriptions are here as reference ONLY. Course content vary from year to year, so any materials on this website might be out of date. We are not responsible for any mistakes in the reviews and descriptions provided herein; however, we will accept notifications as such so we can place appropriate notices.

--- a/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
+++ b/themes/hugo-bootstrap-5/layouts/partials/github-pr-form.html
@@ -116,31 +116,6 @@
         <small id="github-pr-quality-label" style="width: 3rem">3</small>
       </div>
     </div>
-    <div class="my-3">
-      <label for="raffle-email" class="form-label">
-        Raffle Email (Optional)
-        <span class="badge bg-primary">New!</span>
-      </label>
-      <p>
-        <small class="text-muted"
-          >Enter your UBC CWL email here to enter in a raffle to win 50% off a
-          CSSS Hoodie ($22.50 value) or one of five $10 AMS gift cards! Each
-          course review is an entry in the raffle, with a maximum of five
-          entries per person. Raffle will take place at the end of the 2022W2
-          term. This email will not be visible on the published review.</small
-        >
-      </p>
-      <div class="d-flex gap-2">
-        <input
-          class="form-control"
-          type="text"
-          pattern=".*@(student\.|alumni\.)?ubc\.ca"
-          id="github-pr-raffle-email"
-          placeholder="Enter your UBC CWL email"
-          style="width: fit-content;" />
-        <div class="invalid-feedback">Email must end in ubc.ca.</div>
-      </div>
-    </div>
     <div
       class="g-recaptcha my-3"
       data-sitekey="{{ .Site.Params.recaptchaSiteKey }}"></div>


### PR DESCRIPTION
This PR removes the raffle copy from the `/services/courses` page and the 'add new review' form.

I've left the email functionality in the Worker for now. We can reuse it if we plan to run something like this again in coming terms.

Will self-approve this PR.