### PR TITLE
Re-order title

### DIFF
--- a/content/about/team/officers/2021.md
+++ b/content/about/team/officers/2021.md
@@ -1,6 +1,6 @@
 ---
 title: Officers—2021–2022
-date: 2022-06-16
+date: 2021-06-16
 aliases:
   - /club/about/officers/2021
 ---


### PR DESCRIPTION
Small bug but I thought maybe we can keep the [officer titles](https://ubccsss.org/about/team/officers/) in order so we have:

```
Current Officers—2023–2024 
Officers—2022–2023 
Officers—2021–2022 
Officers—2018–2019
``` 
Currently, we have: 
<img width="406" alt="Screenshot 2023-07-05 at 9 27 41 PM" src="https://github.com/ubccsss/ubccsss.org/assets/75223820/cbc95c0b-d64e-4cad-b729-bb7f87ac8371">
