### PR TITLE
Update Installation Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ git clone https://github.com/ubccsss/ubccsss.org.git
 cd ubccsss.org
 
 # ensure that the correct version of Node is used
-nvm use
+nvm install
 
 # install dependencies
 npm install


### PR DESCRIPTION
I updated the bash commands in the installation documentation in the root README.md file. I changed "nvm use" to "nvm update". The command "nvm use" only works if the correct node version is already installed. The command "nvm install" does the same thing, but also installs the correct node version if it isn't already installed.