### PR TITLE
More Broken Links

### DIFF
--- a/content/posts/2019-01-19-career-opportunitiees.md
+++ b/content/posts/2019-01-19-career-opportunitiees.md
@@ -9,10 +9,10 @@ aliases:
 ### Battlesnake
 
 Registration is open for the 2019 Battlesnake Tournament at
-https://www.battlesnake.io/ The tournament is free to compete, a good place to
+https://play.battlesnake.com/ The tournament is free to compete, a good place to
 try out new skills, and there are cash prizes for all 3 tournament divisions.
 More about streaming and in-person tutorials at
-https://www.battlesnake.io/resources/ Feel free to reach out to
+https://play.battlesnake.com/resources/ Feel free to reach out to
 [battlesnake@sendwithus.com](mailto:battlesnake@sendwithus.com) if you have any
 questions!
 

--- a/content/posts/2019-01-19-career-opportunitiees.md
+++ b/content/posts/2019-01-19-career-opportunitiees.md
@@ -12,7 +12,7 @@ Registration is open for the 2019 Battlesnake Tournament at
 https://play.battlesnake.com/ The tournament is free to compete, a good place to
 try out new skills, and there are cash prizes for all 3 tournament divisions.
 More about streaming and in-person tutorials at
-https://play.battlesnake.com/resources/ Feel free to reach out to
+https://docs.battlesnake.com/ Feel free to reach out to
 [battlesnake@sendwithus.com](mailto:battlesnake@sendwithus.com) if you have any
 questions!
 

--- a/themes/hugo-bootstrap-5/theme.toml
+++ b/themes/hugo-bootstrap-5/theme.toml
@@ -1,6 +1,6 @@
 name = "Hugo Bootstrap 5"
 license = "MIT"
-licenselink = "https://github.com/NotWoods/hugo-bootstrap-5/blob/master/LICENSE.md"
+licenselink = "https://github.com/NotWoods/hugo-bootstrap-5/blob/main/LICENSE.md"
 description = "A simple hugo theme using Bootstrap 5"
 homepage = "https://github.com/NotWoods/hugo-bootstrap-5"
 tags = ["blog", "multilingual", "bootstrap"]


### PR DESCRIPTION
Using the new and improved [link-inspector](https://github.com/justindhillon/link-inspector), I found some new broken links. I decided not to fix the links in the _very_ old posts because there won't be much benefit. If you find this pr useful, give [link-inspector](https://github.com/justindhillon/link-inspector) a star :star: 

https://github.com/NotWoods/hugo-bootstrap-5/blob/master/LICENSE.md --> https://github.com/NotWoods/hugo-bootstrap-5/blob/main/LICENSE.md

https://www.battlesnake.io/ --> https://play.battlesnake.com/

https://www.battlesnake.io/resources/ --> https://docs.battlesnake.com/