### PR TITLE
[Study Stack] Revamp!

### DIFF
--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -47,8 +47,8 @@ The UBC CSSS offers the following services.
     {{</ card >}}
   </div>
   <div class="col-md-6 col-xl-4 mb-4 d-flex align-items-stretch">
-    {{< card title="Exams Database" href="https://ubccsss.org/services/exams" src="/files/exams.jpg" >}}
-      We provide a database of old midterm and final exams for review.
+    {{< card title="Study Stack" href="https://ubccsss.org/services/exams" src="/files/exams.jpg" >}}
+      We provide a database of old exams and study resources for review.
     {{</ card >}}
   </div>
 </div>

--- a/content/services/exams/_index.md
+++ b/content/services/exams/_index.md
@@ -12,7 +12,7 @@ images: []
 
 You can find our collection of CPSC exams and quizzes here. They're sorted by year and course. Solutions (where they exist) are also provided.
 
-_NOTE:_ These exams are here as reference ONLY. Examinable materials and course content vary from year to year, so any materials on this website might be out of date. We are not responsible for any mistakes in the solution materials provided herein; however, we will accept notifications as such so we can place appropriate notices.
+_NOTE:_ These exams and hints are here as reference ONLY. Examinable materials and course content vary from year to year, so any materials on this website might be out of date. Exam hints are community-contributed. We are not responsible for any mistakes in the hints or solution materials provided herein; however, we will accept notifications as such so we can place appropriate notices.
 
 ###### Outline
 

--- a/content/services/exams/_index.md
+++ b/content/services/exams/_index.md
@@ -1,16 +1,18 @@
 ---
-title: "Exams Database"
-date: 2017-03-09 03:50:00
+title: "Study Stack"
+date: 2024-01-04 09:00:00
 layout: single
 aliases:
   - /services/exams
-author: Christopher Head
+author: Emilie Ma
 images: []
 ---
 
 ### Please send any exams you have to [vpa@ubccsss.org](mailto:vpa@ubccsss.org)!
 
-You can find our collection of CPSC exams and quizzes here. They're sorted by year and course. Solutions (where they exist) are also provided.
+You can find our collection of CPSC exams, quizzes, and resources here.
+
+They're sorted by year and course. Solutions (where they exist) are also provided. Hints and resources are contributed by the community; feel free to open an issue on GitHub to add a hint.
 
 _NOTE:_ These exams and hints are here as reference ONLY. Examinable materials and course content vary from year to year, so any materials on this website might be out of date. Exam hints are community-contributed. We are not responsible for any mistakes in the hints or solution materials provided herein; however, we will accept notifications as such so we can place appropriate notices.
 

--- a/content/services/exams/_index.md
+++ b/content/services/exams/_index.md
@@ -10,11 +10,11 @@ images: []
 
 ### Please send any exams you have to [vpa@ubccsss.org](mailto:vpa@ubccsss.org)!
 
-You can find our collection of CPSC exams, quizzes, and resources here.
+You can find our collection of CPSC exams, quizzes, and resources here. All rights belong to their respective owners.
 
 They're sorted by year and course. Solutions (where they exist) are also provided. Hints and resources are contributed by the community; feel free to open an issue on GitHub to add a hint.
 
-_NOTE:_ These exams and hints are here as reference ONLY. Examinable materials and course content vary from year to year, so any materials on this website might be out of date. Exam hints are community-contributed. We are not responsible for any mistakes in the hints or solution materials provided herein; however, we will accept notifications as such so we can place appropriate notices.
+_NOTE:_ These exams and hints are here as reference ONLY. Examinable materials and course content vary from year to year, so any materials on this website might be out of date. Exam hints are community-contributed. We are not responsible for any mistakes in the hints or solution materials provided herein; however, we will accept notifications as such so we can place appropriate notices. If you are a professor and would prefer we take down any content, please email [vpa@ubccsss.org](mailto:vpa@ubccsss.org).
 
 ###### Outline
 

--- a/content/services/exams/cpsc101.md
+++ b/content/services/exams/cpsc101.md
@@ -33,6 +33,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc110.md
+++ b/content/services/exams/cpsc110.md
@@ -76,6 +76,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc121.md
+++ b/content/services/exams/cpsc121.md
@@ -67,6 +67,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc173.md
+++ b/content/services/exams/cpsc173.md
@@ -30,6 +30,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc210.md
+++ b/content/services/exams/cpsc210.md
@@ -48,6 +48,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc211.md
+++ b/content/services/exams/cpsc211.md
@@ -28,6 +28,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc213.md
+++ b/content/services/exams/cpsc213.md
@@ -89,6 +89,7 @@ images:
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc221.md
+++ b/content/services/exams/cpsc221.md
@@ -56,6 +56,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc302.md
+++ b/content/services/exams/cpsc302.md
@@ -28,6 +28,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc311.md
+++ b/content/services/exams/cpsc311.md
@@ -44,6 +44,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc312.md
+++ b/content/services/exams/cpsc312.md
@@ -36,6 +36,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc313.md
+++ b/content/services/exams/cpsc313.md
@@ -6,6 +6,14 @@ aliases:
 author: Tristan Rice
 ---
 
+## Resources
+
+- [Former student's review notes](https://github.com/markusdemedeiros/notes_cpsc313)
+- [Casey Cole videos](https://www.youtube.com/watch?v=dFrDy8910j8&list=PLWCT05ePsnGww5psXWHRLG7p30eKKt1Pd)
+- [David Black-Schaffer videos on Virtual Memory](https://github.com/ubccsss/ubccsss.org/edit/master/content/services/exams/_index.md)
+
+_Have other resources to share? [Edit this page on GitHub](https://github.com/ubccsss/ubccsss.org/edit/master/content/services/exams/cpsc320.md) to add them._
+
 ## 2004
 
 - [Midterm 1 (Term 2)](/files/exams/2004/cs313-2004-t2-midterm1.pdf) [(Solution)](/files/exams/2004/cs313-2004-t2-midterm1-solution.pdf)
@@ -61,6 +69,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc314.md
+++ b/content/services/exams/cpsc314.md
@@ -30,6 +30,10 @@ author: Tristan Rice
 - [Midterm](https://ubccsss.org/files/cs314-2016-midterm.pdf)
 - [Midterm (Solution)](https://ubccsss.org/files/cs314-2016-midterm.soln_.pdf)
 
+## 2023
+
+- [Midterm (Term 1)](https://web.archive.org/web/20240105033601/https://www.students.cs.ubc.ca/~cs-314/Vsep2023/mt1-Vsep2023.pdf) [(Solution)](https://web.archive.org/web/20240105033559/https://www.students.cs.ubc.ca/~cs-314/Vsep2023/mt1-Vsep2023-soln.pdf)
+
 ## Undated
 
 - [cs314-midterm2_sample.pdf](/files/exams/undated/cs314-midterm2_sample.pdf)
@@ -53,6 +57,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc320.md
+++ b/content/services/exams/cpsc320.md
@@ -6,6 +6,14 @@ aliases:
 author: Tristan Rice
 ---
 
+## Resources
+
+- [Former TA's course notes](https://web.archive.org/web/20230214134857/https://savreline.com/projects/320notes.pdf)
+- [Open-source solutions for textbook problems](https://github.com/mathiasuy/Soluciones-Klenberg/)
+- [2021 Term 2 assignments](https://web.archive.org/web/20231217163639/http://www.students.cs.ubc.ca/~cs-320/2021W2/index.php?page=assignments&menu=1&submenu=0) and [tutorial problems](https://web.archive.org/web/20231217163656/https://www.students.cs.ubc.ca/~cs-320/2021W2/index.php?page=tutorials&menu=1&submenu=5)
+
+_Have other resources to share? [Edit this page on GitHub](https://github.com/ubccsss/ubccsss.org/edit/master/content/services/exams/cpsc320.md) to add them._
+
 ## 2006
 
 - [Final (Solution)](https://web.archive.org/web/20161215035742/http://www.ugrad.cs.ubc.ca/~cs320/2009S/files/old-final-soln.pdf)
@@ -28,6 +36,12 @@ author: Tristan Rice
 
 - [Sample Final](https://web.archive.org/web/20120201031804/http://www.ugrad.cs.ubc.ca/~cs320/2011W1/handouts/sampleFinal.pdf)
 
+## 2014
+
+- [Practice Final (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2014W2-final-practice.pdf)
+
+{{< exams-hint cpsc320 2014W2F >}}
+
 ## 2016
 
 - [Midterm 1 (Solution)](https://ubccsss.org/files/midterm1-real-comments.pdf)
@@ -37,6 +51,52 @@ author: Tristan Rice
 - [Midterm 2 Sample (Solution)](https://ubccsss.org/files/midterm2-sample-solutions%284%29.pdf)
 - [Sample Final](https://ubccsss.org/files/320-2016-final-sample%281%29.pdf)
 - [Sample Final (Solution)](https://ubccsss.org/files/320-2016-final-sample-solutions%282%29.pdf)
+- [Final (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2016W2-final.pdf)
+
+## 2017
+
+- [Midterm 1 (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W1-midterm1.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W1-midterm1-soln.pdf)
+
+{{< exams-hint cpsc320 2017W1MT1 >}}
+
+- [Midterm 2 (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W1-midterm2.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W1-midterm2-soln.pdf)
+
+{{< exams-hint cpsc320 2017W1MT2 >}}
+
+- [Midterm 1 (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W2-midterm1.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W2-midterm1-soln.pdf)
+
+{{< exams-hint cpsc320 2017W2MT1 >}}
+
+- [Midterm 2 (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W2-midterm2.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2017W1-midterm2-soln.pdf)
+
+{{< exams-hint cpsc320 2017W2MT2 >}}
+
+## 2018
+
+- [Midterm 1 (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2018W1-midterm1.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2018W1-midterm1-soln.pdf)
+
+{{< exams-hint cpsc320 2018W1MT1 >}}
+
+- [Midterm 2 (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2018W1-midterm2.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2018W1-midterm2-soln.pdf)
+
+{{< exams-hint cpsc320 2018W1MT2 >}}
+
+## 2019
+
+- [Final (Summer Term 2)](https://web.archive.org/web/20240105020536/https://www.students.cs.ubc.ca/~cs-320/2022W1/handouts/old-exams/2019S2-final.pdf)
+
+{{< exams-hint cpsc320 2019S2F >}}
+
+## 2020
+
+- [Take-home Test 1 (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-test1.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-test1-soln.pdf)
+- [Midterm (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-midterm.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-midterm-soln.pdf)
+- [Take-home Test 2 (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-test2.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-test2-soln.pdf)
+- [Final (Term 1)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W1-final.pdf)
+- [Take-home Test 1 (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-test1.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-test1-soln.pdf)
+- [Midterm (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-midterm.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-midterm-soln.pdf)
+- [Take-home Test 2 (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-test2.pdf) [(Solution)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-test2-soln.pdf)
+- [Final (Term 2)](https://web.archive.org/web/20231217163506if_/https://www.students.cs.ubc.ca/~cs-320/2021W2/handouts/old-exams/2020W2-final.pdf)
 
 ###### Outline
 
@@ -60,3 +120,5 @@ author: Tristan Rice
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)
 - [Uncategorized](/services/exams/uncategorized)
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>

--- a/content/services/exams/cpsc320.md
+++ b/content/services/exams/cpsc320.md
@@ -116,6 +116,7 @@ _Have other resources to share? [Edit this page on GitHub](https://github.com/ub
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc322.md
+++ b/content/services/exams/cpsc322.md
@@ -14,6 +14,12 @@ author: Tristan Rice
 - [Midterm (Term 1) (Solution)](/files/exams/2010/cs322-2010-t1-midterm-solution.pdf)
 - [Final Review (Term 1)](/files/exams/2010/cs322-2010-t1-review-final.pdf)
 
+## 2020
+
+- [Practice Midterm 1 (Term 1)](https://web.archive.org/web/20211023003220/https://www.cs.ubc.ca/~poole/cs322/2020/exams/prmid1.pdf) [(Solution)](https://web.archive.org/web/20211023003220/https://www.cs.ubc.ca/~poole/cs322/2020/exams/prmid1sol.pdf)
+- [Practice Midterm 2 (Term 1)](https://web.archive.org/web/20211023003220/https://www.cs.ubc.ca/~poole/cs322/2020/exams/prmid2.pdf) [(Solution)](https://web.archive.org/web/20211023003220/https://www.cs.ubc.ca/~poole/cs322/2020/exams/prmid2sol.pdf)
+- [Practice Final (Term 1)](https://web.archive.org/web/20211023003220/https://www.cs.ubc.ca/~poole/cs322/2020/exams/prfin.pdf) [(Solution)](https://web.archive.org/web/20211023003220/https://www.cs.ubc.ca/~poole/cs322/2020/exams/prfin_sol.pdf)
+
 ###### Outline
 
 - [CPSC 101](/services/exams/cpsc101)
@@ -32,6 +38,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc340.md
+++ b/content/services/exams/cpsc340.md
@@ -1,17 +1,14 @@
 ---
-title: CPSC 310
-date: 2016-11-29 20:38:00
+title: CPSC 340
+date: 2024-01-04 19:38:00
 aliases:
-  - /services/exams/cpsc310
-author: Tristan Rice
+  - /services/exams/cpsc340
+author: Emilie Ma
 ---
 
-## 2009
+## 2020
 
-- [Midterm 1 (Summer)](/files/exams/2009/cs310-2009-s-midterm1.pdf)
-- [Midterm 2 (Summer)](/files/exams/2009/cs310-2009-s-midterm2.pdf)
-- [Midterm 3 (Summer)](/files/exams/2009/cs310-2009-s-midterm3.pdf)
-- [Sample Final (Summer)](/files/exams/2009/cs310-2009-s-sample-final.pdf) [(Solution)](/files/exams/2009/cs310-2009-s-sample-final-solution.pdf)
+- [Final (W1)](https://web.archive.org/web/20240105033146/https://www.cs.ubc.ca/~fwood/CS340/final.pdf)
 
 ###### Outline
 

--- a/content/services/exams/cpsc404.md
+++ b/content/services/exams/cpsc404.md
@@ -41,6 +41,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc422.md
+++ b/content/services/exams/cpsc422.md
@@ -28,6 +28,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/cpsc448b.md
+++ b/content/services/exams/cpsc448b.md
@@ -28,6 +28,7 @@ author: Tristan Rice
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/content/services/exams/uncategorized.md
+++ b/content/services/exams/uncategorized.md
@@ -49,6 +49,7 @@ We've also collected some PDFs that we weren't able to match find a course quiz/
 - [CPSC 314](/services/exams/cpsc314)
 - [CPSC 320](/services/exams/cpsc320)
 - [CPSC 322](/services/exams/cpsc322)
+- [CPSC 340](/services/exams/cpsc340)
 - [CPSC 404](/services/exams/cpsc404)
 - [CPSC 422](/services/exams/cpsc422)
 - [CPSC 448B](/services/exams/cpsc448B)

--- a/data/exams/cpsc320.yaml
+++ b/data/exams/cpsc320.yaml
@@ -1,0 +1,118 @@
+2014W2F:
+  - question: Q2
+    hint: Think about the quantities each problem is trying to maximize and minimize, the restrictions it applies (e.g. no two students who don't trust each other on the same machine), and what problems might map to these factors.
+  - question: Q3.5
+    hint: Use the existing 'count-inversions' algorithm, but write a wrapper that places the pivot for the first call in a specific way. You don't necessarily have to use the results of all returned recursive calls.
+  - question: Q4
+    hint: See [this StackExchange post](https://cs.stackexchange.com/a/95597).
+  - question: Q5.8
+    hint: Is `q` one of the parameters of the instance of SQ?
+  - question: Q6.5
+    hint: How many possible assignments are there now?
+  - question: Q6.6
+    hint: Consider one 'part' as one player's territories, and the other 'part' as the other player's. Since the graph is bipartite, can there be any connections between territories within a player's control? What does this say about their territories' connected components' maximum size?
+2017W2MT1:
+  - question: Q1
+    hint: Note the question restriction that m < n. Big-O bounds with multiple variables are incomparable if the relationship differs depending on m or n's growth rate.
+  - question: Q2
+    hint: Always try to come up with a counterexample for this type of question, so at least half of the work is done!
+  - question: Q2.1
+    hint: Weakly-connected means that if the graph was undirected, it would be connected. A connected graph has a minimum of n - 1 edges.
+  - question: Q2.2
+    hint: Consider a situation where a woman's preferences are \'important\' to the resulting matching. Does having any arbitrariness in her decision change the possible matchings?
+  - question: Q3
+    hint: Being \'unique to that component\' means that the colour is only in that component and is unique across components.
+  - question: Q3.2
+    hint: Consider what impact requiring that the arrays were sorted has and what parts of the code rely on that assumption.
+  - question: Q4.2
+    hint: Fill this in according to the reduction you just formulated.
+  - question: Q5.1
+    hint: An STP instance of size `k` where everyone is indifferent has `k!` solutions, because no one has any preferences that could cause instabilities, so this is just the number of possible matchings.
+  - question: Q5.2
+    hint: Think of a mentorship relationship as being a parent in a tree. Because everyone must have a mentor, can any mentor go without a mentor? What does this say about the number of edges, and by extension, the number of cycles? Is this an upper or lower bound?
+  - question: Q6
+    hint: What happens if you have a very generous donor who \'fills up\' a cause with a very small amount remaining? Was this the best use of their \'one cause\'?
+2017W2MT2:
+  - question: Q1
+    hint: Does the `first` argument ever get used? Which of the arguments contributes to the decision to continue recursing?
+  - question: Q3.1
+    hint: What does quick select do even before recursively calling anything?
+  - question: Q4
+    hint: Try partitioning the elements so that all the majority elements are in one subarray and none are in the others.
+  - question: Q4.4
+    hint: What parts of either problem have to do with 'majority'? BLAME produces an arbitrary set of nodes if a majority of the nodes were not intact. How does this help simplify the 'no instance' case?
+  - question: Q6
+    hint: If an element is a majority element, it must occupy the 'middle' position of the sorted array. What is the rank of that element?
+2017W1MT1:
+  - question: Q1.2b
+    hint: If we know the array is sorted, and that there are two different numbers, what are some 'easy' positions we can look in to find them?
+  - question: Q1.4
+    hint: Can you find an expression for the number of dashed edges? What about for the height? Draw out some example trees (e.g. a 'star') to see if the height / number of dashed edges changes.
+  - question: Q2.1
+    hint: If two men share the same preference list, they will both start by trying to propose to the same woman. Can both of them succeed in the end?
+  - question: Q2.3
+    hint: Try n = 5. Then try n = 2.
+  - question: Q3
+    hint: Is there a sample instance that returns something you didn't expect? What part of the reduction caused that to happen?
+2017W1MT2:
+  - question: Q1
+    hint: Always try to come up with a counterexample for this type of question, so at least half of the work is done!
+  - question: Q2
+    hint: This 'majority' pattern comes up a lot in past midterms.
+  - question: Q2.3
+    hint: The blank `A[mid] ___ A[hi]` is expecting 'faces', 'not equal' or 'equal'.
+  - question: Q3
+    hint: The last answer is another way of saying 'choose the performance that ends first'.
+  - question: Q4.3
+    hint: If we 'run out' of the first string, we don't have to continue. We also can't skip any letters within the first string, so there's one case of LCS we don't have to consider.
+  - question: Q5.2a
+    hint: The base case is still a subproblem.
+  - question: Q5.2c
+    hint: How many units of time do you need to spend computing E(100)? E(50)? E(0)?
+2018W1MT1:
+  - question: Q1.1
+    hint: Consider the definition of little-o.
+  - question: Q1.2
+    hint: Consider the property that `log (n^k) = k log(n)`
+  - question: Q1.4
+    hint: What two bounds are implied by a limit of big-theta? If the big-O bound is true, what must not be true?
+  - question: Q1.5
+    hint: Consider how raising something to exponent (`n^x`) versus something to c * exponent (`n^(cx)`) changes the expression.
+  - question: Q3.2
+    hint: The number of 2-exchanges is equal to the number of ways the patients and donors can be paired up.
+  - question: Q3.4
+    hint: Does it matter in what order we choose the edges?
+2018W1MT2:
+  - question: Q2.1
+    hint: Consider a graph that forms a path, and consider what restrictions are imposed on the choice of e for the 'end nodes'.
+  - question: Q2.2
+    hint: What is the definition of a tree? One property is guaranteed by the algorithm. If we assume the other property is violated, how can we show a contradiction based on the fact that the weights differ?
+  - question: Q4
+    hint: One shortcut is to bound the time taken at the root of the tree for a lower bound, then the time taken over infinite levels of the tree for an upper bound.
+  - question: Q5.3
+    hint: Consider what the 'natural ordering' is of the subproblems. What do you have to compute before computing Pell(n)? Also, reference the memoized algorithm you just wrote.
+  - question: Q5.5
+    hint: How many entries maximum do you ever reference in computing `Soln[n]`?
+2019S2F:
+  - question: Q1.1
+    hint: What is the formula for `(n+1)!`? Recall that `(c^x)^y = (c^y)^x`.
+  - question: Q1.2e
+    hint: The Gale-Shapley algorithm always produces the matching that matches each employer to its best valid applicant and each applicant to its worst valid employer.
+  - question: Q1.4
+    hint: What extra work does the DP solution have to do for each coin value?
+  - question: Q2
+    hint: The correct form of reduction from SAT to 3SAT, as shown in class, requires one of the `y_i` to be negated. What requirement did that impose on the 3SAT reduction? This reduction from 4SAT to 3SAT doesn't have that negation, but has a similar 'joining' structure. Does this cause any issues where an unsatisfiable instance of 4SAT can become satisfiable in the reduced 3SAT?
+  - question: Q3.2
+    hint: This becomes the minimum spanning tree problem.
+  - question: Q3.3
+    hint: What is the definition of NP - specifically, what does it require about the runtime of one of its certification algorithms? Recall that a `polynomial * polynomial = polynomial`.
+  - question: Q5.2
+    hint: What is the definition of the master theorem? Does it place any restrictions on the size of the different subproblems?
+  - question: Q6.1
+    hint: Does this graph have to be directed? If we have word A that can be transformed to word B in one step, can we 'reverse' it? Does this graph have to be weighted? What are we counting?
+  - question: Q6.4
+    hint: For each word in your dictionary, what transformations can be done on it? Assuming all words were valid, what are the maximum number of unique transformations that can be applied to one word? The english alphabet has 26 letters.
+  - question: Q7
+    hint: For the recurrence, try coming up with a solution where you assume each step only makes one 'cut'.
+  - question: Q8.2
+    hint: Person 1 will be the first person selected, because they only speak 2 languages. What happens if Persons 2 and 3 share no languages, but they each share a language with Person 1?

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,7 +18,13 @@
       {{ range $recentEvents }}{{ .Render "card" }}{{ end }}
     </div>
     <div class="row justify-content-center pt-lg-2 pb-lg-4">
-      <div class="col-lg-8 text-center">Have a suggested event or initiative in mind? Send it our way <a href="https://docs.google.com/forms/d/e/1FAIpQLSdS49z5TPjGM9Iwrfh4SAxuok6UBaP_lKtMi98qWj30NHaRjA/viewform">here</a>.</div>
+      <div class="col-lg-8 text-center">
+        Have a suggested event or initiative in mind? Send it our way
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLSdS49z5TPjGM9Iwrfh4SAxuok6UBaP_lKtMi98qWj30NHaRjA/viewform"
+          >here</a
+        >.
+      </div>
     </div>
     <hr class="w-75 mx-auto" />
     <div class="row mb-4 mt-5 py-lg-4">
@@ -138,11 +144,11 @@
               <div class="card-body">
                 <h5 class="card-title">
                   <a class="card-link" href="https://ubccsss.org/services/exams"
-                    >Exams Database</a
+                    >Study Stack</a
                   >
                 </h5>
                 <p class="card-text">
-                  We provide a database of old midterm and final exams for
+                  We provide a database of old exams and study resources for
                   review.
                 </p>
               </div>

--- a/themes/hugo-bootstrap-5/layouts/shortcodes/exams-hint.html
+++ b/themes/hugo-bootstrap-5/layouts/shortcodes/exams-hint.html
@@ -1,0 +1,51 @@
+{{ $key := printf "-accordion" | printf "%s%s" (.Get 1) | printf "%s%s" (.Get 0) | printf "%s" }}
+<div class="accordion mb-3" id="{{ $key }}">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="heading{{ $key }}">
+      <button
+        class="accordion-button collapsed"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#collapse{{ $key }}"
+        aria-controls="collapse{{ $key }}">
+        Show hints
+      </button>
+    </h2>
+    <div
+      id="collapse{{ $key }}"
+      class="accordion-collapse collapse"
+      aria-labelledby="heading{{ $key }}"
+      data-bs-parent="#{{ $key }}">
+      <div class="accordion-body">
+        <div class="accordion" id="sub-{{ $key }}">
+          {{ with (index (index $.Site.Data.exams (.Get 0)) (.Get 1)) }}
+            {{ range $index, $el := . }}
+              <div class="accordion-item">
+                <h2 class="accordion-header" id="sub-heading{{ $key }}">
+                  <button
+                    class="accordion-button collapsed"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#sub-collapse{{ $key }}{{ $index }}"
+                    aria-expanded="true"
+                    aria-controls="collapse{{ $key }}">
+                    {{ $el.question }}
+                  </button>
+                </h2>
+                <div
+                  id="sub-collapse{{ $key }}{{ $index }}"
+                  class="accordion-collapse collapse"
+                  aria-labelledby="sub-heading{{ $key }}"
+                  data-bs-parent="#sub-{{ $key }}">
+                  <div class="accordion-body">
+                    {{ $el.hint | markdownify }}
+                  </div>
+                </div>
+              </div>
+            {{ end }}
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds:
- an `exams-hint` shortcode that pulls from `data/exams/<course>.yaml` to render hints (easiest way to add hints without massively restructuring existing exam pages)
- an additional 'resources' section to some courses
- additional past exams that I scrounged around to find
...and renames the Exams DB to the Study Stack.

Keeping as a draft PR before I bring it up with exec team / academic team!