### PR TITLE
[TCF] Add past event notes on 2023 pages

### DIFF
--- a/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-companies.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-companies.html
@@ -3,7 +3,7 @@
   <head>
     {{ partial "head-meta" . }}
     <link rel="canonical" href="{{ .Permalink }}" />
-    <title>UBC Technical Career Fair 2023</title>
+    <title>[Past Event] UBC Technical Career Fair 2023</title>
     <!-- Bootstrap CSS -->
     <link
       rel="stylesheet"
@@ -60,6 +60,9 @@
     <div class="container">
       <a href="/tcf">&lt; back to TCF page</a>
       <div class="row pt-4">
+        <p>
+          <b>Looking for TCF 2024? Go <a href="/tcf">here</a>.</b>
+        </p>
         {{ range .Site.Pages }}
           {{ if (and (eq .Params.layout "tcf-company") (.Params.imageLink)) }}
             <div class="col-lg-3 col-sm-12 col-md-6 mt-3">

--- a/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-company.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-company.html
@@ -6,7 +6,7 @@
 
     <link rel="canonical" href="{{ .Permalink }}" />
 
-    <title>UBC Technical Career Fair 2023</title>
+    <title>[Past Event] UBC Technical Career Fair 2023</title>
 
     <!-- Bootstrap CSS -->
     <link
@@ -85,6 +85,9 @@
             class="mw-100 w-100 img-shadow img-outline p-3" />
         </div>
         <div class="col">
+          <p>
+            <b>Looking for TCF 2024? Go <a href="/tcf">here</a>.</b>
+          </p>
           <p>{{ .Params.short_bio | markdownify }}</p>
           <p>
             <a href="{{ .Params.link }}" class="btn btn-primary"

--- a/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-day-of.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-day-of.html
@@ -6,7 +6,7 @@
 
     <link rel="canonical" href="{{ .Permalink }}" />
 
-    <title>UBC Technical Career Fair 2023</title>
+    <title>[Past Event] UBC Technical Career Fair 2023</title>
 
     <!-- Bootstrap CSS -->
     <link

--- a/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-main.html
+++ b/themes/hugo-bootstrap-5/layouts/tcf2023/tcf-main.html
@@ -6,7 +6,7 @@
 
     <link rel="canonical" href="{{ .Permalink }}" />
 
-    <title>UBC Technical Career Fair 2023</title>
+    <title>[Past Event] UBC Technical Career Fair 2023</title>
 
     <!-- Bootstrap CSS -->
     <link
@@ -66,6 +66,12 @@
           <p class="hero-header-text">UBC CSSS presents</p>
           <h1 class="display-1 fw-bold">Technical Career Fair 2023</h1>
           <p>January 19, 2023 ◦ 10AM - 4PM PST ◦ Great Hall in the AMS Nest</p>
+          <p>
+            <b
+              >Looking for TCF 2024? Go
+              <a href="/tcf" style="color: white">here</a>.</b
+            >
+          </p>
           <div class="d-flex pt-3 flex-row gap-3 justify-content-center">
             <a href="/tcf2023/companies" class="btn btn-light">
               <i class="bi-people"></i> See companies


### PR DESCRIPTION
This PR adds (as per Alice):
- `[Past Event]` to the title of each of the 2023 TCF pages
- a 'looking for TCF 2024?' link to each of the old pages:
![image](https://github.com/ubccsss/ubccsss.org/assets/45278276/94f5c301-c0d8-46ed-b719-98fad00cf258)

Let me know if you have anywhere else you'd like to add a note!