### PR TITLE
Something about package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ubccsss.org",
   "version": "0.0.1",
+  "private": true,
   "description": "Website for the UBC CSSS",
   "repository": "https://github.com/ubccsss/ubccsss.org.git",
   "engines": {


### PR DESCRIPTION
I added ```"private": true``` to package.json. This prevents someone from accidentally publishing the website to the npm repositories. This is standard practice for websites that use npm.

Documentation: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#private