### PR TITLE
Added Code of Conduct 

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -9,12 +9,12 @@ We are the UBC Computer Science Student Society (UBC CSSS), a student society to
 serve all Computer Science students.
 
 <div class="mb-4">
-  <a class="btn btn-primary" href="/about/team/executives">Executives</a>
-  <a class="btn btn-primary" href="/about/team/officers/">Officers</a>
-  <a class="btn btn-primary" href="/about/constitution">Constitution</a>
-  <a class="btn btn-primary" href="/about/minutes/">Minutes</a>
-  <a class="btn btn-primary" href="/about/partners/">Partners</a>
-  <a class="btn btn-primary" href="/about/code-of-conduct/">Code of Conduct</a>
+  <a class="btn btn-primary me-1 mb-2" href="/about/team/executives">Executives</a>
+  <a class="btn btn-primary me-1 mb-2" href="/about/team/officers/">Officers</a>
+  <a class="btn btn-primary me-1 mb-2" href="/about/constitution">Constitution</a>
+  <a class="btn btn-primary me-1 mb-2" href="/about/minutes/">Minutes</a>
+  <a class="btn btn-primary me-1 mb-2" href="/about/partners/">Partners</a>
+  <a class="btn btn-primary me-1 mb-2" href="/about/code-of-conduct/">Code of Conduct</a>
 </div>
 
 ### How do I join?

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -14,6 +14,7 @@ serve all Computer Science students.
   <a class="btn btn-primary" href="/about/constitution">Constitution</a>
   <a class="btn btn-primary" href="/about/minutes/">Minutes</a>
   <a class="btn btn-primary" href="/about/partners/">Partners</a>
+  <a class="btn btn-primary" href="/about/code-of-conduct/">Code of Conduct</a>
 </div>
 
 ### How do I join?

--- a/content/about/code-of-conduct.md
+++ b/content/about/code-of-conduct.md
@@ -1,0 +1,33 @@
+---
+title: Code of Conduct
+---
+
+Code of Conduct for CSSS, Cube Lounge/Office, Discord Server, and other CSSS Community Spaces
+
+&nbsp;&nbsp;
+
+### Rules:
+
+&nbsp;
+
+1. **This is an Official CSSS Space.** Do your part to make the space inclusive and enjoyable for everyone!
+
+2. **Treat everyone with kindness and respect** while engaging in thoughtful and friendly conversations. Harassment, sexism, racism, prejudice, or hateful speech toward any identifiable group will not be tolerated. Avoid heated political debates and focus on discussing ideas rather than individuals.
+
+3. **While we appreciate this is a casual space to connect, keep it professional.** NSFW content is prohibited, including sexualized language or explicit material. This includes profile photos and nicknames; consider using a server profile if this applies to your main account.
+
+4. **Respect others’ privacy.** Do not doxx or otherwise publish personal information without the individuals’ consent.
+
+5. **No spam, please!** If you have something relevant to share or promote, please consult with a moderator first. We’ll also determine if it’s suitable for promotion through our announcements channel for added visibility. 🙂
+
+6. **ALL PROVISIONS OF THE UBC STUDENT CODE OF CONDUCT APPLY,** regardless of your status as a UBC community member.
+
+7. **Disciplinary actions for misconduct** will be pursued through the appropriate UBC channels. Academic dishonesty will be reported to UBC through the academic dishonesty channels, while other misconduct will be addressed through the UBC Non-Academic Misconduct Process.
+
+8. **Please help us maintain a positive environment** by reporting any misconduct to a moderator immediately. Your prompt action helps us address issues quickly and ensure a respectful community for everyone.
+
+&nbsp;
+
+Thanks, and enjoy your stay!
+
+&nbsp;

--- a/content/about/code-of-conduct.md
+++ b/content/about/code-of-conduct.md
@@ -2,9 +2,9 @@
 title: Code of Conduct
 ---
 
-Code of Conduct for CSSS, Cube Lounge/Office, Discord Server, and other CSSS Community Spaces
+Code of Conduct for CSSS, Cube Lounge/Office, Discord Server, and other CSSS Community Spaces.
 
-&nbsp;&nbsp;
+<br/>
 
 ### Rules:
 

--- a/data/footer.yaml
+++ b/data/footer.yaml
@@ -17,3 +17,4 @@
     - /about/minutes
     - /volunteer
     - /contact/suggestions-box
+    - /about/code-of-conduct


### PR DESCRIPTION
This pull request adds the Code of Conduct to the About page and includes a link to it in the footer


### About Page
#### Previous: 
<img width="651" alt="Screen Shot 2024-09-08 at 8 47 37 PM" src="https://github.com/user-attachments/assets/c80900ec-4e04-4c43-b478-57f846968279">


#### After: 

<img width="651" alt="Screen Shot 2024-09-08 at 8 46 30 PM" src="https://github.com/user-attachments/assets/f0cf9ac7-d592-4338-bba5-e09f766c2a89">


### Code of Conduct Page
<img width="567" alt="Screen Shot 2024-09-08 at 8 48 19 PM" src="https://github.com/user-attachments/assets/77fd6124-492d-4624-9470-fdc9d7f9b816">


### Footer


#### Previous: 
<img width="1147" alt="Screen Shot 2024-09-08 at 8 48 35 PM" src="https://github.com/user-attachments/assets/04d36edb-7963-420a-8c1b-eaff009cb4ca">

#### After: 

<img width="1147" alt="Screen Shot 2024-09-08 at 8 48 59 PM" src="https://github.com/user-attachments/assets/dd8ff199-0a52-41e4-8d00-9e7f8b84e7b3">
