### PR TITLE
feat: Add 'icon-image' class to social icons for dark mode styling

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -91,8 +91,17 @@
     localStorage.setItem("darkmode", !wasDarkmode);
     if (DarkReader.isEnabled()) {
       DarkReader.disable();
+      updateSocialIconColors(false);
     } else {
       DarkReader.enable();
+      updateSocialIconColors(true);
     }
+  }
+
+  function updateSocialIconColors(isDarkMode) {
+    const socialIcons = document.querySelectorAll(".icon-image");
+    socialIcons.forEach((icon) => {
+      icon.style.filter = isDarkMode ? "invert(100%)" : "invert(0%)";
+    });
   }
 </script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -84,6 +84,10 @@
   if (localStorage.getItem("darkmode") === "true") {
     DarkReader.enable();
     document.getElementById("darkMode").checked = true;
+    // Delay added to ensure DarkReader completes styling before icon color update
+    setTimeout(() => updateSocialIconColors(true), 100);
+  } else {
+    updateSocialIconColors(false);
   }
 
   function darkMode() {

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,10 +10,11 @@
 
   <section>
     <h4>{{ i18n "elsewhere" }}</h4>
-    <ul>
+    <ul style="list-style: none; padding: 0; margin: 0;">
       {{ range $.Site.Data.social }}
-        <li style="list-style:url('{{ .icon }}')">
+        <li>
           <a href="{{ .link }}">
+            <img src="{{ .icon }}" alt="{{ .title }} Icon" class="icon-image" />
             {{ if or (eq .title "Discord") (eq .title "Instagram") }}
               <b>{{ .title }}</b>
             {{ else }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b390eaae-d4f1-467a-8976-cd61f1f49974)


- Updated <img> tags in the social media section to include the 'icon-image' class.
- Enables JavaScript control over icon colors based on dark mode toggle.
- Added a 100ms delay to allow DarkReader to fully apply its styles
  before updating social icon colors.