### PR TITLE
Landing page event carousels

### DIFF
--- a/content/events/2024-10-18-hacktoberfest-git-workshop.md
+++ b/content/events/2024-10-18-hacktoberfest-git-workshop.md
@@ -12,9 +12,9 @@ author: Sean Tang
 images:
   - /files/2024-10-18-hacktober1.png
 # Start date and time. Used for calendar page.
-start_date: 2024-10-24 17:30:00
+start_date: 2024-11-03 17:30:00
 # End date and time (defaults to one hour after start). Used for calendar page.
-end_date: 2024-10-24 19:30:00
+end_date: 2024-11-05 19:30:00
 ---
 
 ![Preview image for Hacktoberfest Git Workshop event](/files/2024-10-18-hacktober1.png)

--- a/content/events/2024-10-18-hacktoberfest-git-workshop.md
+++ b/content/events/2024-10-18-hacktoberfest-git-workshop.md
@@ -12,9 +12,9 @@ author: Sean Tang
 images:
   - /files/2024-10-18-hacktober1.png
 # Start date and time. Used for calendar page.
-start_date: 2024-11-03 17:30:00
+start_date: 2024-10-24 17:30:00
 # End date and time (defaults to one hour after start). Used for calendar page.
-end_date: 2024-11-05 19:30:00
+end_date: 2024-10-24 19:30:00
 ---
 
 ![Preview image for Hacktoberfest Git Workshop event](/files/2024-10-18-hacktober1.png)

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,6 +24,24 @@
     .display-none {
       display: none;
     }
+
+    .carousel-control-prev {
+      width: 5%;
+      justify-content: left;
+    }
+
+    .carousel-control-next {
+      width: 5%;
+      justify-content: right;
+    }
+
+    .carousel-control-next-icon {
+      filter: invert(100%);
+    }
+
+    .carousel-control-prev-icon {
+      filter: invert(100%);
+    }
   </style>
 
   <script>
@@ -116,7 +134,7 @@
           </button>
         </div>
       {{ else }}
-        <p class="text-center fs-5 p-4">
+        <p class="text-center p-4">
           No upcoming events at the moment. Check back later!
         </p>
         <p></p>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,12 +1,18 @@
 {{ define "body" }}
   {{ $displayEventType := "upcoming" }}
-  {{ $upcomingEvents := (.Site.GetPage "/events").Pages | first 24 }}
-  {{ $pastEvents := (.Site.GetPage "/events").Pages | first 24 }}
+  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 24 }}
+  {{ $upcomingEvents := where $recentEvents "Params.date" "ge" now }}
+  {{ $pastEvents := where $recentEvents "Params.date" "lt" now }}
+  {{ $upcomingEventsLength := len $upcomingEvents }}
 
 
   <style>
     .nav-tabs .nav-link.active {
       background-color: #fcfcfc;
+    }
+
+    .display-none {
+      display: none;
     }
   </style>
 
@@ -56,7 +62,7 @@
         <li class="nav-item">
           <a
             id="events-nav-bar-upcoming"
-            class="nav-link active"
+            class="nav-link {{ if ne $upcomingEventsLength 0 }}active{{ end }}"
             aria-current="page"
             onclick="showEvents('upcoming', this)"
             >Upcoming Events</a
@@ -65,7 +71,7 @@
         <li class="nav-item">
           <a
             id="events-nav-bar-past"
-            class="nav-link"
+            class="nav-link {{ if eq $upcomingEventsLength 0 }}active{{ end }}"
             onclick="showEvents('past', this)"
             >Past Events</a
           >
@@ -73,33 +79,43 @@
       </ul>
     </div>
 
-    <div id="eventsCarouselUpcoming">
-      <div
-        id="carouselControlsUpcoming"
-        class="carousel slide"
-        data-bs-ride="carousel"
-        style="display: block;">
-        <div id="events-carousel-upcoming" class="carousel-inner">
-          {{ partial "display-events.html" (dict "events" $upcomingEvents) }}
+    <div
+      id="eventsCarouselUpcoming"
+      class="{{ if eq $upcomingEventsLength 0 }}display-none{{ end }}">
+      {{ if ne $upcomingEventsLength 0 }}
+        <div
+          id="carouselControlsUpcoming"
+          class="carousel slide"
+          data-bs-ride="carousel">
+          <div id="events-carousel-upcoming" class="carousel-inner">
+            {{ partial "display-events.html" (dict "events" $upcomingEvents) }}
+          </div>
+          <button
+            class="carousel-control-prev"
+            type="button"
+            data-bs-target="#carouselControlsUpcoming"
+            data-bs-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          </button>
+          <button
+            class="carousel-control-next"
+            type="button"
+            data-bs-target="#carouselControlsUpcoming"
+            data-bs-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          </button>
         </div>
-        <button
-          class="carousel-control-prev"
-          type="button"
-          data-bs-target="#carouselControlsUpcoming"
-          data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-        </button>
-        <button
-          class="carousel-control-next"
-          type="button"
-          data-bs-target="#carouselControlsUpcoming"
-          data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-        </button>
-      </div>
+      {{ else }}
+        <p class="text-center fs-5 p-4">
+          No upcoming events at the moment. Check back later!
+        </p>
+        <p></p>
+      {{ end }}
     </div>
 
-    <div id="eventsCarouselPast" style="display: none;">
+    <div
+      id="eventsCarouselPast"
+      class="{{ if ne $upcomingEventsLength 0 }}display-none{{ end }}">
       <div
         id="carouselControlsPast"
         class="carousel slide"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,24 +24,6 @@
     .display-none {
       display: none;
     }
-
-    .carousel-control-prev {
-      width: 5%;
-      justify-content: left;
-    }
-
-    .carousel-control-next {
-      width: 5%;
-      justify-content: right;
-    }
-
-    .carousel-control-next-icon {
-      filter: invert(100%);
-    }
-
-    .carousel-control-prev-icon {
-      filter: invert(100%);
-    }
   </style>
 
   <script>
@@ -111,28 +93,7 @@
       id="eventsCarouselUpcoming"
       class="{{ if eq $upcomingEventsLength 0 }}display-none{{ end }}">
       {{ if ne $upcomingEventsLength 0 }}
-        <div
-          id="carouselControlsUpcoming"
-          class="carousel slide"
-          data-bs-ride="carousel">
-          <div id="events-carousel-upcoming" class="carousel-inner">
-            {{ partial "display-events.html" (dict "events" $upcomingEvents) }}
-          </div>
-          <button
-            class="carousel-control-prev"
-            type="button"
-            data-bs-target="#carouselControlsUpcoming"
-            data-bs-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          </button>
-          <button
-            class="carousel-control-next"
-            type="button"
-            data-bs-target="#carouselControlsUpcoming"
-            data-bs-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          </button>
-        </div>
+        {{ partial "event-carousel.html" (dict "controlsId" "carouselControlsUpcoming" "events" $upcomingEvents) }}
       {{ else }}
         <p class="text-center p-4">
           No upcoming events at the moment. Check back later!
@@ -144,28 +105,7 @@
     <div
       id="eventsCarouselPast"
       class="{{ if ne $upcomingEventsLength 0 }}display-none{{ end }}">
-      <div
-        id="carouselControlsPast"
-        class="carousel slide"
-        data-bs-ride="carousel">
-        <div id="events-carousel-past" class="carousel-inner">
-          {{ partial "display-events.html" (dict "events" $pastEvents) }}
-        </div>
-        <button
-          class="carousel-control-prev"
-          type="button"
-          data-bs-target="#carouselControlsPast"
-          data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-        </button>
-        <button
-          class="carousel-control-next"
-          type="button"
-          data-bs-target="#carouselControlsPast"
-          data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-        </button>
-      </div>
+      {{ partial "event-carousel.html" (dict "controlsId" "carouselControlsPast" "events" $pastEvents) }}
     </div>
 
     <div class="row justify-content-center pt-lg-2 pb-lg-4">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,19 +1,13 @@
 {{ define "body" }}
-  {{/* Carousel event chunking script */}}
+  {{ $displayEventType := "upcoming" }}
   {{ $recentEvents := (.Site.GetPage "/events").Pages | first 24 }}
-  {{ $batchSize := 4 }}
-  {{ $chunks := dict }}
-  {{ $current_key := 0 }}
 
-  {{ range $i, $event := $recentEvents }}
-    {{ if and (ne $i 0) (eq (mod $i $batchSize) 0) }}
-      {{ $current_key = add $current_key 1 }}
-    {{ end }}
-    {{ $chunk := index $chunks (string $current_key) | default (slice) }}
-    {{ $chunk = $chunk | append $event }}
-    {{ $chunks = merge $chunks (dict (string $current_key) $chunk) }}
-  {{ end }}
 
+  <style>
+    .nav-tabs .nav-link.active {
+      background-color: #fcfcfc;
+    }
+  </style>
 
   <div class="container-fluid">
     <div class="row justify-content-center pt-3 mb-lg-5 mb-3 text-center">
@@ -25,29 +19,39 @@
     <hr class="w-75 mx-auto" />
     <div class="row justify-content-center mt-3 py-lg-4">
       <div class="col-lg-8 text-center large-text">
-        <h1>Recent Events</h1>
+        <h1>Our Events</h1>
       </div>
     </div>
-    <div
-      id="carouselExampleControls"
-      class="carousel slide"
-      data-bs-ride="carousel">
+
+    <ul class="nav nav-tabs">
+      <li class="nav-item">
+        <a
+          class="nav-link {{ if eq $displayEventType "upcoming" }}
+            active
+          {{ end }}"
+          aria-current="page"
+          href="#"
+          >Upcoming Events</a
+        >
+      </li>
+      <li class="nav-item">
+        <a
+          class="nav-link {{ if eq $displayEventType "past" }}active{{ end }}"
+          href="#"
+          >Past Events</a
+        >
+      </li>
+    </ul>
+    <div id="carouselControls" class="carousel slide" data-bs-ride="carousel">
       <div class="carousel-inner">
-        {{ range $chunkIndex, $chunk := $chunks }}
-          <div class="carousel-item {{ if eq $chunkIndex "0" }}active{{ end }}">
-            <div
-              class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 px-5 pt-lg-3 pt-3 g-4">
-              {{ range $event := $chunk }}
-                {{ .Render "card" }}
-              {{ end }}
-            </div>
-          </div>
+        {{ if eq $displayEventType "upcoming" }}
+          {{ partial "display-events.html" (dict "events" $recentEvents) }}
         {{ end }}
       </div>
       <button
         class="carousel-control-prev"
         type="button"
-        data-bs-target="#carouselExampleControls"
+        data-bs-target="#carouselControls"
         data-bs-slide="prev">
         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
         <span class="visually-hidden">Previous</span>
@@ -55,7 +59,7 @@
       <button
         class="carousel-control-next"
         type="button"
-        data-bs-target="#carouselExampleControls"
+        data-bs-target="#carouselControls"
         data-bs-slide="next">
         <span class="carousel-control-next-icon" aria-hidden="true"></span>
         <span class="visually-hidden">Next</span>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,25 +51,27 @@
       </div>
     </div>
 
-    <ul class="nav nav-tabs">
-      <li class="nav-item">
-        <a
-          id="events-nav-bar-upcoming"
-          class="nav-link active"
-          aria-current="page"
-          onclick="showEvents('upcoming', this)"
-          >Upcoming Events</a
-        >
-      </li>
-      <li class="nav-item">
-        <a
-          id="events-nav-bar-past"
-          class="nav-link"
-          onclick="showEvents('past', this)"
-          >Past Events</a
-        >
-      </li>
-    </ul>
+    <div style="margin-left: 3rem; margin-right: 3rem;">
+      <ul class="nav nav-tabs">
+        <li class="nav-item">
+          <a
+            id="events-nav-bar-upcoming"
+            class="nav-link active"
+            aria-current="page"
+            onclick="showEvents('upcoming', this)"
+            >Upcoming Events</a
+          >
+        </li>
+        <li class="nav-item">
+          <a
+            id="events-nav-bar-past"
+            class="nav-link"
+            onclick="showEvents('past', this)"
+            >Past Events</a
+          >
+        </li>
+      </ul>
+    </div>
 
     <div id="eventsCarouselUpcoming">
       <div

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,21 @@
 {{ define "body" }}
+  {{/* Carousel event chunking script */}}
+  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 25 }}
+  {{ $batchSize := 4 }}
+  {{ $chunks := dict }}
+  {{ $current_key := 0 }}
+
+  {{ range $i, $event := $recentEvents }}
+    {{ if and (ne $i 0) (eq (mod $i $batchSize) 0) }}
+      {{ $current_key = add $current_key 1 }}
+    {{ end }}
+    {{ $chunk := index $chunks (string $current_key) | default (slice) }}
+    {{ $chunk = $chunk | append $event }}
+    {{ $chunks = merge $chunks (dict (string $current_key) $chunk) }}
+  {{ end }}
+
+
   <div class="container-fluid">
-    {{ $recentEvents := (.Site.GetPage "/events").Pages | first 4 }}
     <div class="row justify-content-center pt-3 mb-lg-5 mb-3 text-center">
       <div class="w-75 col-lg-10 title">
         <h1 class="mb-lg-4">{{ .Title }}</h1>
@@ -14,9 +29,39 @@
       </div>
     </div>
     <div
-      class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 px-5 pt-lg-3 pt-3 g-4">
-      {{ range $recentEvents }}{{ .Render "card" }}{{ end }}
+      id="carouselExampleControls"
+      class="carousel slide"
+      data-bs-ride="carousel">
+      <div class="carousel-inner">
+        {{ range $chunkIndex, $chunk := $chunks }}
+          <div class="carousel-item {{ if eq $chunkIndex "0" }}active{{ end }}">
+            <div
+              class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 px-5 pt-lg-3 pt-3 g-4">
+              {{ range $event := $chunk }}
+                {{ .Render "card" }}
+              {{ end }}
+            </div>
+          </div>
+        {{ end }}
+      </div>
+      <button
+        class="carousel-control-prev"
+        type="button"
+        data-bs-target="#carouselExampleControls"
+        data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Previous</span>
+      </button>
+      <button
+        class="carousel-control-next"
+        type="button"
+        data-bs-target="#carouselExampleControls"
+        data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Next</span>
+      </button>
     </div>
+
     <div class="row justify-content-center pt-lg-2 pb-lg-4">
       <div class="col-lg-8 text-center">
         Have a suggested event or initiative in mind? Send it our way

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,10 +3,12 @@
   {{ $recentEvents := (.Site.GetPage "/events").Pages | first 28 }}
   {{ $upcomingEvents := slice }}
   {{ $pastEvents := slice }}
+  {{ $truncatedNow := now.Format "2006-01-02" | time }}
 
   {{ range $i, $event := $recentEvents }}
     {{ $startDate := time $event.Params.start_date }}
-    {{ if ge $startDate now }}
+    {{ $truncatedStartDate := $startDate.Format "2006-01-02" | time }}
+    {{ if ge $truncatedStartDate $truncatedNow }}
       {{ $upcomingEvents = $upcomingEvents | append $event }}
     {{ else }}
       {{ $pastEvents = $pastEvents | append $event }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "body" }}
   {{/* Carousel event chunking script */}}
-  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 25 }}
+  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 24 }}
   {{ $batchSize := 4 }}
   {{ $chunks := dict }}
   {{ $current_key := 0 }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "body" }}
 
-  {{ /* Fetch and split events into upcoming and past */ }}
+  <!-- Fetch and split events into upcoming and past -->
   {{ $displayEventType := "upcoming" }}
   {{ $recentEvents := (.Site.GetPage "/events").Pages | first 28 }}
   {{ $upcomingEvents := slice }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,8 +9,10 @@
 
   {{ range $i, $event := $recentEvents }}
     {{ $startDate := time $event.Params.start_date }}
+    {{ $endDate := time $event.Params.end_date }}
     {{ $truncatedStartDate := $startDate.Format "2006-01-02" | time }}
-    {{ if ge $truncatedStartDate $truncatedNow }}
+    {{ $truncatedEndDate := $endDate.Format "2006-01-02" | time }}
+    {{ if or (ge $truncatedStartDate $truncatedNow) (ge $truncatedEndDate $truncatedNow) }}
       {{ $upcomingEvents = $upcomingEvents | append $event }}
     {{ else }}
       {{ $pastEvents = $pastEvents | append $event }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,7 @@
 {{ define "body" }}
   {{ $displayEventType := "upcoming" }}
-  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 24 }}
+  {{ $upcomingEvents := (.Site.GetPage "/events").Pages | first 24 }}
+  {{ $pastEvents := (.Site.GetPage "/events").Pages | first 24 }}
 
 
   <style>
@@ -8,6 +9,33 @@
       background-color: #fcfcfc;
     }
   </style>
+
+  <script>
+    /**
+     * Dynamically shows and hides event carousels.
+     */
+    function showEvents(eventType, element) {
+      pastEventsCarousel = document.getElementById("eventsCarouselPast");
+      upcomingEventsCarousel = document.getElementById(
+        "eventsCarouselUpcoming"
+      );
+
+      document.getElementById("events-nav-bar-past").classList.remove("active");
+      document
+        .getElementById("events-nav-bar-upcoming")
+        .classList.remove("active");
+
+      element.classList.add("active");
+
+      if (eventType === "upcoming") {
+        upcomingEventsCarousel.style.display = "block";
+        pastEventsCarousel.style.display = "none";
+      } else {
+        upcomingEventsCarousel.style.display = "none";
+        pastEventsCarousel.style.display = "block";
+      }
+    }
+  </script>
 
   <div class="container-fluid">
     <div class="row justify-content-center pt-3 mb-lg-5 mb-3 text-center">
@@ -26,44 +54,72 @@
     <ul class="nav nav-tabs">
       <li class="nav-item">
         <a
-          class="nav-link {{ if eq $displayEventType "upcoming" }}
-            active
-          {{ end }}"
+          id="events-nav-bar-upcoming"
+          class="nav-link active"
           aria-current="page"
-          href="#"
+          onclick="showEvents('upcoming', this)"
           >Upcoming Events</a
         >
       </li>
       <li class="nav-item">
         <a
-          class="nav-link {{ if eq $displayEventType "past" }}active{{ end }}"
-          href="#"
+          id="events-nav-bar-past"
+          class="nav-link"
+          onclick="showEvents('past', this)"
           >Past Events</a
         >
       </li>
     </ul>
-    <div id="carouselControls" class="carousel slide" data-bs-ride="carousel">
-      <div class="carousel-inner">
-        {{ if eq $displayEventType "upcoming" }}
-          {{ partial "display-events.html" (dict "events" $recentEvents) }}
-        {{ end }}
+
+    <div id="eventsCarouselUpcoming">
+      <div
+        id="carouselControlsUpcoming"
+        class="carousel slide"
+        data-bs-ride="carousel"
+        style="display: block;">
+        <div id="events-carousel-upcoming" class="carousel-inner">
+          {{ partial "display-events.html" (dict "events" $upcomingEvents) }}
+        </div>
+        <button
+          class="carousel-control-prev"
+          type="button"
+          data-bs-target="#carouselControlsUpcoming"
+          data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        </button>
+        <button
+          class="carousel-control-next"
+          type="button"
+          data-bs-target="#carouselControlsUpcoming"
+          data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        </button>
       </div>
-      <button
-        class="carousel-control-prev"
-        type="button"
-        data-bs-target="#carouselControls"
-        data-bs-slide="prev">
-        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-        <span class="visually-hidden">Previous</span>
-      </button>
-      <button
-        class="carousel-control-next"
-        type="button"
-        data-bs-target="#carouselControls"
-        data-bs-slide="next">
-        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-        <span class="visually-hidden">Next</span>
-      </button>
+    </div>
+
+    <div id="eventsCarouselPast" style="display: none;">
+      <div
+        id="carouselControlsPast"
+        class="carousel slide"
+        data-bs-ride="carousel">
+        <div id="events-carousel-past" class="carousel-inner">
+          {{ partial "display-events.html" (dict "events" $pastEvents) }}
+        </div>
+        <button
+          class="carousel-control-prev"
+          type="button"
+          data-bs-target="#carouselControlsPast"
+          data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        </button>
+        <button
+          class="carousel-control-next"
+          type="button"
+          data-bs-target="#carouselControlsPast"
+          data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        </button>
+      </div>
     </div>
 
     <div class="row justify-content-center pt-lg-2 pb-lg-4">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,6 @@
 {{ define "body" }}
+
+  {{ /* Fetch and split events into upcoming and past */ }}
   {{ $displayEventType := "upcoming" }}
   {{ $recentEvents := (.Site.GetPage "/events").Pages | first 28 }}
   {{ $upcomingEvents := slice }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,18 +30,18 @@
     /**
      * Dynamically shows and hides event carousels.
      */
-    function showEvents(eventType, element) {
-      pastEventsCarousel = document.getElementById("eventsCarouselPast");
-      upcomingEventsCarousel = document.getElementById(
-        "eventsCarouselUpcoming"
-      );
-
+    function showEvents(eventType, clickedElement) {
       document.getElementById("events-nav-bar-past").classList.remove("active");
       document
         .getElementById("events-nav-bar-upcoming")
         .classList.remove("active");
 
-      element.classList.add("active");
+      clickedElement.classList.add("active");
+
+      const pastEventsCarousel = document.getElementById("eventsCarouselPast");
+      const upcomingEventsCarousel = document.getElementById(
+        "eventsCarouselUpcoming"
+      );
 
       if (eventType === "upcoming") {
         upcomingEventsCarousel.style.display = "block";

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "body" }}
   {{ $displayEventType := "upcoming" }}
-  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 24 }}
+  {{ $recentEvents := (.Site.GetPage "/events").Pages | first 28 }}
   {{ $upcomingEvents := slice }}
   {{ $pastEvents := slice }}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,8 +1,18 @@
 {{ define "body" }}
   {{ $displayEventType := "upcoming" }}
   {{ $recentEvents := (.Site.GetPage "/events").Pages | first 24 }}
-  {{ $upcomingEvents := where $recentEvents "Params.date" "ge" now }}
-  {{ $pastEvents := where $recentEvents "Params.date" "lt" now }}
+  {{ $upcomingEvents := slice }}
+  {{ $pastEvents := slice }}
+
+  {{ range $i, $event := $recentEvents }}
+    {{ $startDate := time $event.Params.start_date }}
+    {{ if ge $startDate now }}
+      {{ $upcomingEvents = $upcomingEvents | append $event }}
+    {{ else }}
+      {{ $pastEvents = $pastEvents | append $event }}
+    {{ end }}
+  {{ end }}
+
   {{ $upcomingEventsLength := len $upcomingEvents }}
 
 

--- a/layouts/partials/display-events.html
+++ b/layouts/partials/display-events.html
@@ -1,4 +1,4 @@
-{{/* Carousel event chunking script */}}
+<!-- Carousel event chunking script -->
 {{ $batchSize := 4 }}
 {{ $chunks := dict }}
 {{ $current_key := 0 }}

--- a/layouts/partials/display-events.html
+++ b/layouts/partials/display-events.html
@@ -37,7 +37,7 @@
 {{ range $chunkIndex, $chunk := $chunks }}
   <div class="carousel-item {{ if eq $chunkIndex "0" }}active{{ end }}">
     <div
-      class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 px-5 pt-lg-3 pt-3 g-4">
+      class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 px-5 pt-lg-3 pt-3 g-4 justify-content-center">
       {{ range $event := $chunk }}
         {{ .Render "card" }}
       {{ end }}

--- a/layouts/partials/display-events.html
+++ b/layouts/partials/display-events.html
@@ -1,0 +1,46 @@
+{{/* Carousel event chunking script */}}
+{{ $batchSize := 4 }}
+{{ $chunks := dict }}
+{{ $current_key := 0 }}
+
+{{ range $i, $event := .events }}
+  {{ if and (ne $i 0) (eq (mod $i $batchSize) 0) }}
+    {{ $current_key = add $current_key 1 }}
+  {{ end }}
+  {{ $chunk := index $chunks (string $current_key) | default (slice) }}
+  {{ $chunk = $chunk | append $event }}
+  {{ $chunks = merge $chunks (dict (string $current_key) $chunk) }}
+{{ end }}
+
+
+<style>
+  .carousel-control-prev {
+    width: 5%;
+    justify-content: left;
+  }
+
+  .carousel-control-next {
+    width: 5%;
+    justify-content: right;
+  }
+
+  .carousel-control-next-icon {
+    background-color: black;
+    opacity: 100%;
+  }
+
+  .carousel-control-prev-icon {
+    background-color: black;
+  }
+</style>
+
+{{ range $chunkIndex, $chunk := $chunks }}
+  <div class="carousel-item {{ if eq $chunkIndex "0" }}active{{ end }}">
+    <div
+      class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 px-5 pt-lg-3 pt-3 g-4">
+      {{ range $event := $chunk }}
+        {{ .Render "card" }}
+      {{ end }}
+    </div>
+  </div>
+{{ end }}

--- a/layouts/partials/display-events.html
+++ b/layouts/partials/display-events.html
@@ -12,28 +12,6 @@
   {{ $chunks = merge $chunks (dict (string $current_key) $chunk) }}
 {{ end }}
 
-
-<style>
-  .carousel-control-prev {
-    width: 5%;
-    justify-content: left;
-  }
-
-  .carousel-control-next {
-    width: 5%;
-    justify-content: right;
-  }
-
-  .carousel-control-next-icon {
-    background-color: black;
-    opacity: 100%;
-  }
-
-  .carousel-control-prev-icon {
-    background-color: black;
-  }
-</style>
-
 {{ range $chunkIndex, $chunk := $chunks }}
   <div class="carousel-item {{ if eq $chunkIndex "0" }}active{{ end }}">
     <div

--- a/layouts/partials/event-carousel.html
+++ b/layouts/partials/event-carousel.html
@@ -1,0 +1,39 @@
+<style>
+  .carousel-control-prev {
+    width: 5%;
+    justify-content: left;
+  }
+
+  .carousel-control-next {
+    width: 5%;
+    justify-content: right;
+  }
+
+  .carousel-control-next-icon {
+    filter: invert(100%);
+  }
+
+  .carousel-control-prev-icon {
+    filter: invert(100%);
+  }
+</style>
+
+<div id="{{ .controlsId }}" class="carousel slide" data-bs-ride="carousel">
+  <div class="carousel-inner">
+    {{ partial "display-events.html" (dict "events" .events) }}
+  </div>
+  <button
+    class="carousel-control-prev"
+    type="button"
+    data-bs-target="#{{ .controlsId }}"
+    data-bs-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+  </button>
+  <button
+    class="carousel-control-next"
+    type="button"
+    data-bs-target="#{{ .controlsId }}"
+    data-bs-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+  </button>
+</div>

--- a/themes/hugo-bootstrap-5/layouts/_default/card.html
+++ b/themes/hugo-bootstrap-5/layouts/_default/card.html
@@ -1,6 +1,6 @@
 {{ $startDateStr := .Params.start_date | default .Date }}
 
-{{ /* Highlight card script */ }}
+<!-- Highlight card script -->
 {{ $startDate := time $startDateStr }}
 {{ $formattedDate := $startDate.Format "2006-01-02" | time }}
 {{ $formattedNow := now.Format "2006-01-02" | time }}

--- a/themes/hugo-bootstrap-5/layouts/_default/card.html
+++ b/themes/hugo-bootstrap-5/layouts/_default/card.html
@@ -15,7 +15,7 @@
 <div class="col">
   <div
     class="card mb-4 shadow-sm h-md-250 {{ if $isSoon }}
-      border border-warning
+      border border-primary
     {{ end }}">
     {{ if isset .Params "images" }}
       {{ if gt (len .Params.images) 0 }}

--- a/themes/hugo-bootstrap-5/layouts/_default/card.html
+++ b/themes/hugo-bootstrap-5/layouts/_default/card.html
@@ -5,9 +5,9 @@
 {{ $secondsInDay := 86400 }}
 {{ $dayDiff := div (sub $startDate.Unix now.Unix) $secondsInDay }}
 
-{{ $withinDays := 7 }}
+{{ $days := 7 }}
 {{ $isSoon := false }}
-{{ if and (ge $dayDiff 0) (lt $dayDiff $withinDays) }}
+{{ if and (ge $dayDiff 0) (le $dayDiff $days) }}
   {{ $isSoon = true }}
 {{ end }}
 

--- a/themes/hugo-bootstrap-5/layouts/_default/card.html
+++ b/themes/hugo-bootstrap-5/layouts/_default/card.html
@@ -1,9 +1,10 @@
 {{ $startDateStr := .Params.start_date | default .Date }}
 {{ $startDate := time $startDateStr }}
-{{ $formattedDate := $startDate.Format "2006-01-02" }}
+{{ $formattedDate := $startDate.Format "2006-01-02" | time }}
+{{ $formattedNow := now.Format "2006-01-02" | time }}
 
 {{ $secondsInDay := 86400 }}
-{{ $dayDiff := div (sub $startDate.Unix now.Unix) $secondsInDay }}
+{{ $dayDiff := div (sub $formattedDate.Unix $formattedNow.Unix) $secondsInDay }}
 
 {{ $days := 7 }}
 {{ $isSoon := false }}

--- a/themes/hugo-bootstrap-5/layouts/_default/card.html
+++ b/themes/hugo-bootstrap-5/layouts/_default/card.html
@@ -1,4 +1,6 @@
 {{ $startDateStr := .Params.start_date | default .Date }}
+
+{{ /* Highlight card script */ }}
 {{ $startDate := time $startDateStr }}
 {{ $formattedDate := $startDate.Format "2006-01-02" | time }}
 {{ $formattedNow := now.Format "2006-01-02" | time }}

--- a/themes/hugo-bootstrap-5/layouts/_default/card.html
+++ b/themes/hugo-bootstrap-5/layouts/_default/card.html
@@ -1,6 +1,22 @@
-{{ $startDate := .Params.start_date | default .Date }}
+{{ $startDateStr := .Params.start_date | default .Date }}
+{{ $startDate := time $startDateStr }}
+{{ $formattedDate := $startDate.Format "2006-01-02" }}
+
+{{ $secondsInDay := 86400 }}
+{{ $dayDiff := div (sub $startDate.Unix now.Unix) $secondsInDay }}
+
+{{ $withinDays := 7 }}
+{{ $isSoon := false }}
+{{ if and (ge $dayDiff 0) (lt $dayDiff $withinDays) }}
+  {{ $isSoon = true }}
+{{ end }}
+
+
 <div class="col">
-  <div class="card mb-4 shadow-sm h-md-250">
+  <div
+    class="card mb-4 shadow-sm h-md-250 {{ if $isSoon }}
+      border border-warning
+    {{ end }}">
     {{ if isset .Params "images" }}
       {{ if gt (len .Params.images) 0 }}
         <img class="card-img-top" src="{{ (index .Params.images 0) }}" />
@@ -12,7 +28,7 @@
       </h5>
       {{ if not (eq .Params.layout "courses") }}
         <p class="card-text mb-1 text-muted">
-          {{ dateFormat "Mon Jan 2, 2006" $startDate }}
+          {{ dateFormat "Mon Jan 2, 2006" $startDateStr }}
         </p>
       {{ end }}
       {{ with .Params.location }}


### PR DESCRIPTION
Added a carousel for events on the landing page with tabs: upcoming and past.

**Notes:**
- Carousels will show the 28 most recent events in total.
- On page load, the upcoming events tab will be selected by default. If there are no upcoming events, the past events carousel will be selected instead.
- All events filtering is on a day basis; time is not considered. This means:
  - Events starting and ending on the same day are moved to the past events carousel a day after the event start date. E.g an event occurring Nov 4th will remain in the upcoming events carousel for the whole day, even if the event finished earlier that day.
  - If an event spans multiple days, the event will remain in upcoming events until it concludes.
- An event is highlighted if it's occurring within the next 7 days (again, time is not considered).

**Before**
<img width="500" alt="Screenshot 2024-11-04 at 10 17 38 PM" src="https://github.com/user-attachments/assets/3032f347-af43-49af-9a19-7f4722fd63e1">

**After**
<img width="500" alt="Screenshot 2024-11-04 at 10 24 07 PM" src="https://github.com/user-attachments/assets/dff22bcc-0bcc-40ee-893e-1f463439c005">

<img width="500" alt="Screenshot 2024-11-04 at 10 27 25 PM" src="https://github.com/user-attachments/assets/02ff8939-c7e0-41af-8dee-1051745b1c72">

<img width="500" alt="Screenshot 2024-11-04 at 10 25 18 PM" src="https://github.com/user-attachments/assets/606766f1-7d49-4a19-aa69-003e1f3a9205">
